### PR TITLE
Drive the cart drawer from a URL search param

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,13 +9,35 @@
 	},
 	"editor.defaultFormatter": "biomejs.biome",
 	"editor.formatOnSave": true,
-	"files.readonlyInclude": { "**/routeTree.gen.ts": true },
-	"files.watcherExclude": { "**/routeTree.gen.ts": true },
-	"search.exclude": { "**/routeTree.gen.ts": true },
+	"editor.quickSuggestions": {
+		"strings": "on"
+	},
+	"files.associations": {
+		"*.css": "tailwindcss"
+	},
+	"js/ts.tsdk.path": "node_modules/typescript/lib",
+	"search.exclude": {
+		"**/routeTree.gen.ts": true
+	},
+	"tailwindCSS.classAttributes": [
+		"class",
+		"className",
+		"enter",
+		"enterFrom",
+		"enterTo",
+		"leave",
+		"leaveFrom",
+		"leaveTo"
+	],
+	"tailwindCSS.classFunctions": ["clsx", "cn", "cva"],
 	"tailwindCSS.experimental.classRegex": [
 		["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
 		["cn\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
 		["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
 	],
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"tailwindCSS.experimental.configFile": "apps/web/app/tailwind.css",
+	"tailwindCSS.lint.cssConflict": "warning",
+	"tailwindCSS.lint.recommendedVariantOrder": "warning",
+	"tailwindCSS.lint.suggestCanonicalClasses": "warning",
+	"tailwindCSS.validate": true
 }

--- a/apps/web/app/components/cart-content.tsx
+++ b/apps/web/app/components/cart-content.tsx
@@ -1,0 +1,360 @@
+import { CheckIcon, ChevronLeftIcon, ChevronRightIcon, ClockIcon, XMarkIcon } from '@heroicons/react/20/solid';
+import { Image } from '@unpic/react';
+import { clsx } from 'clsx';
+import { Form, Link, useFetcher, useNavigation } from 'react-router';
+import type { CartView } from '../lib/cart-model';
+import { CART_ACTIONS, CART_INTENT } from '../lib/cart-actions';
+import { formatMoney } from '../lib/format-money';
+import type { LineDisplay } from '../lib/line-display';
+import { Button, ButtonLink } from './design-system/button';
+import { Heading } from './design-system/heading';
+import { PayPalMessages } from './paypal';
+
+type CartSuccess = Extract<CartView, { type: 'success' }>;
+type CartResult = CartSuccess | { type: 'empty' | 'error' };
+
+type CartContentProps = {
+	result: CartResult;
+	showHeading?: boolean;
+	summaryPlacement?: 'inline' | 'footer';
+};
+
+export function CartContent({ result, showHeading = true, summaryPlacement = 'inline' }: CartContentProps) {
+	if (result.type !== 'success' || result.cart.lines.edges.length === 0) {
+		return <EmptyCart placement={summaryPlacement} showHeading={showHeading} />;
+	}
+
+	return <FilledCart result={result} showHeading={showHeading} summaryPlacement={summaryPlacement} />;
+}
+
+function EmptyCart({ showHeading, placement }: { showHeading: boolean; placement: 'inline' | 'footer' }) {
+	// In the drawer (footer placement) fill the panel and centre the message so it
+	// doesn't cling to the top with a tall empty void beneath it.
+	if (placement === 'footer') {
+		return (
+			<div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-6 px-4 text-center">
+				<p className="text-gray-600">Your cart is currently empty.</p>
+				<ButtonLink href="/" variant="neutral">
+					Continue shopping
+				</ButtonLink>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-6 text-center">
+			{showHeading && (
+				<Heading headingElement="h1" size="2">
+					Shopping Cart
+				</Heading>
+			)}
+			<p>Your cart is currently empty.</p>
+			<span>
+				<ButtonLink href="/" variant="neutral">
+					Continue shopping
+				</ButtonLink>
+			</span>
+		</div>
+	);
+}
+
+function FilledCart({
+	result,
+	showHeading,
+	summaryPlacement,
+}: {
+	result: CartSuccess;
+	showHeading: boolean;
+	summaryPlacement: 'inline' | 'footer';
+}) {
+	const navigation = useNavigation();
+	const { cart, linesDisplay } = result;
+
+	if (summaryPlacement === 'footer') {
+		return (
+			<div className="@container/cart flex min-h-0 flex-1 flex-col">
+				{showHeading && (
+					<div className="px-4 pt-6">
+						<Heading headingElement="h1" size="2">
+							Shopping Cart
+						</Heading>
+					</div>
+				)}
+
+				<section aria-labelledby="cart-heading" className="min-h-0 flex-1 overflow-y-auto px-4">
+					<h2 className="sr-only" id="cart-heading">
+						Items in your shopping cart
+					</h2>
+					<CartLines linesDisplay={linesDisplay} result={result} />
+				</section>
+
+				<CartSummary cart={cart} isPending={navigation.state !== 'idle'} placement="footer" />
+			</div>
+		);
+	}
+
+	return (
+		<div className="@container/cart flex flex-col gap-10">
+			{showHeading && (
+				<Heading headingElement="h1" size="2">
+					Shopping Cart
+				</Heading>
+			)}
+			<div className="grid @5xl/cart:grid-cols-[minmax(0,1fr)_minmax(18rem,0.42fr)] grid-cols-1 items-start @5xl/cart:gap-12 gap-10">
+				<section aria-labelledby="cart-heading">
+					<h2 className="sr-only" id="cart-heading">
+						Items in your shopping cart
+					</h2>
+					<CartLines linesDisplay={linesDisplay} result={result} />
+				</section>
+
+				<CartSummary cart={cart} isPending={navigation.state !== 'idle'} placement="inline" />
+			</div>
+		</div>
+	);
+}
+
+function CartLines({ result, linesDisplay }: { result: CartSuccess; linesDisplay: Array<LineDisplay> }) {
+	return (
+		<ul className="divide-y divide-gray-200 border-gray-200 border-t border-b" role="list">
+			{result.cart.lines.edges.map(({ node }, index) => {
+				const theme = node.merchandise.product.tags.includes('ladies') ? 'ladies' : 'mens';
+
+				return (
+					<li className="flex gap-4 py-6" data-theme={theme} key={node.id}>
+						<div className="shrink-0">
+							{node.merchandise.image?.url ? (
+								<Image
+									alt={node.merchandise.image.altText ?? ''}
+									className="aspect-square @3xl/cart:w-40 w-24 object-contain object-center"
+									height={192}
+									layout="constrained"
+									priority={false}
+									src={node.merchandise.image.url}
+									width={192}
+								/>
+							) : (
+								<span className="block aspect-square @3xl/cart:w-40 w-24 bg-gray-200" />
+							)}
+						</div>
+
+						<div className="flex min-w-0 flex-1 flex-col gap-4">
+							<div className="relative grid @4xl/cart:grid-cols-[minmax(0,1fr)_auto] grid-cols-1 gap-4 pr-9">
+								<div className="min-w-0">
+									<h3 className="text-sm">
+										<Link
+											className="text-gray-700 hover:text-gray-800"
+											prefetch="intent"
+											to={`/${theme}/products/${node.merchandise.product.handle}`}
+										>
+											{node.merchandise.product.title}
+										</Link>
+									</h3>
+									{node.merchandise.title !== 'Default Title' && (
+										<p className="mt-1 text-gray-500 text-sm">{node.merchandise.title}</p>
+									)}
+									<LineItemPrice display={linesDisplay[index]} />
+								</div>
+
+								<div className="@4xl/cart:pr-9">
+									<QuantityPicker
+										quantity={node.quantity}
+										quantityAvailable={node.merchandise.quantityAvailable ?? 0}
+										variantId={node.merchandise.id}
+									/>
+									<RemoveFromCart variantId={node.merchandise.id} />
+								</div>
+							</div>
+
+							<p className="flex gap-2 text-gray-700 text-sm">
+								{node.merchandise.currentlyNotInStock ? (
+									<ClockIcon aria-hidden="true" className="h-5 w-5 shrink-0 text-gray-300" />
+								) : (
+									<CheckIcon aria-hidden="true" className="h-5 w-5 shrink-0 text-green-500" />
+								)}
+								<span>{node.merchandise.currentlyNotInStock ? 'Out of stock' : 'In stock'}</span>
+							</p>
+						</div>
+					</li>
+				);
+			})}
+		</ul>
+	);
+}
+
+function CartSummary({
+	cart,
+	isPending,
+	placement,
+}: {
+	cart: CartSuccess['cart'];
+	isPending: boolean;
+	placement: 'inline' | 'footer';
+}) {
+	return (
+		<Form
+			action="/cart"
+			aria-labelledby="summary-heading"
+			className={clsx(
+				'flex flex-col gap-6 bg-gray-50 px-4 py-6',
+				placement === 'footer' && 'shrink-0 border-gray-200 border-t',
+			)}
+			method="post"
+		>
+			<h2 className="text-gray-900 text-lg" id="summary-heading">
+				Order summary
+			</h2>
+
+			<dl className="space-y-4">
+				<div className="flex items-center justify-between gap-4">
+					<dt className="text-gray-600 text-sm">Subtotal</dt>
+					<dd className="text-gray-900 text-sm">{formatMoney(cart.cost.subtotalAmount)}</dd>
+				</div>
+			</dl>
+
+			{/*
+			 * Only the full cart page renders PayPal messaging. The drawer (footer
+			 * placement) overlays product pages that already mount a PayPal provider,
+			 * and the PayPal SDK is a global singleton: a second provider unmounting
+			 * (e.g. when the cart empties) tears down every PayPal component and
+			 * crashes the page. Keeping one provider per view avoids that.
+			 */}
+			{placement === 'inline' && (
+				<PayPalMessages amount={Number(cart.cost.subtotalAmount.amount || 0)} placement="cart" />
+			)}
+			<p className="text-gray-600 text-sm">Taxes and shipping are calculated at checkout</p>
+
+			{cart.checkoutUrl && (
+				<>
+					<input name="checkoutUrl" type="hidden" value={cart.checkoutUrl} />
+					<Button
+						disabled={isPending}
+						name={CART_INTENT}
+						type="submit"
+						value={CART_ACTIONS.CHECKOUT_ACTION}
+						variant="neutral"
+					>
+						Checkout
+					</Button>
+				</>
+			)}
+		</Form>
+	);
+}
+
+function LineItemPrice({ display }: { display: LineDisplay | undefined }) {
+	if (display == null) return null;
+
+	return (
+		<div className="mt-1 flex flex-col gap-0.5 text-gray-900 text-sm">
+			{display.showWasNow && display.compareAt != null && (
+				<del className="text-gray-500">
+					<span className="sr-only">Was </span>
+					{formatMoney(display.compareAt, 'AUD')}
+				</del>
+			)}
+			<span>
+				{display.showWasNow && display.compareAt != null && <span className="sr-only">Now </span>}
+				{formatMoney(display.pricePerUnit, 'AUD')}
+			</span>
+			{display.discountLabels.map(({ label, amount }, index) => (
+				<span className="text-gray-600 text-xs" key={index}>
+					{label} {amount != null && ` (-${formatMoney(amount, 'AUD')})`}
+				</span>
+			))}
+		</div>
+	);
+}
+
+function QuantityPicker({
+	variantId,
+	quantity,
+	quantityAvailable,
+}: {
+	variantId: string;
+	quantity: number;
+	quantityAvailable: number;
+}) {
+	const fetcher = useFetcher();
+	const isPending = fetcher.state !== 'idle';
+
+	return (
+		<div className="flex flex-col items-start gap-2">
+			<span className="text-gray-700 text-sm hover:text-gray-800">Quantity</span>
+			<span className="isolate inline-flex shadow-sm">
+				<fetcher.Form action="/cart" method="post">
+					<input name="variantId" type="hidden" value={variantId} />
+					<input name="quantity" type="hidden" value={quantity - 1} />
+					<button
+						className={clsx(
+							'relative inline-flex items-center border border-gray-300 bg-white px-2 py-2 text-gray-700 text-sm',
+							'hover:bg-gray-50',
+							'focus:z-10 focus:border-brand-primary focus:outline-hidden focus:ring-1 focus:ring-brand-primary',
+							'disabled:opacity-50',
+							isPending && 'opacity-50',
+						)}
+						data-testid="quantity-decrement"
+						disabled={quantity <= 1}
+						name={CART_INTENT}
+						type="submit"
+						value={CART_ACTIONS.DECREMENT_ACTION}
+					>
+						<ChevronLeftIcon aria-hidden="true" className="h-5 w-5" />
+					</button>
+				</fetcher.Form>
+				<span
+					className={clsx(
+						isPending && 'opacity-50',
+						'relative -ml-px inline-flex items-center border border-gray-300 bg-white px-4 py-2 text-gray-700 text-sm',
+					)}
+					data-testid="quantity-display"
+				>
+					{quantity}
+				</span>
+				<fetcher.Form action="/cart" method="post">
+					<input name="variantId" type="hidden" value={variantId} />
+					<input name="quantity" type="hidden" value={quantity + 1} />
+					<button
+						className={clsx(
+							'relative -ml-px inline-flex items-center border border-gray-300 bg-white px-2 py-2 text-gray-700 text-sm',
+							'hover:bg-gray-50',
+							'focus:z-10 focus:border-brand-primary focus:outline-hidden focus:ring-1 focus:ring-brand-primary',
+							'disabled:opacity-50',
+							isPending && 'opacity-50',
+						)}
+						data-testid="quantity-increment"
+						disabled={quantity + 1 >= quantityAvailable}
+						name={CART_INTENT}
+						type="submit"
+						value={CART_ACTIONS.INCREMENT_ACTION}
+					>
+						<ChevronRightIcon aria-hidden="true" className="h-5 w-5" />
+					</button>
+				</fetcher.Form>
+			</span>
+		</div>
+	);
+}
+
+function RemoveFromCart({ variantId }: { variantId: string }) {
+	const fetcher = useFetcher();
+
+	return (
+		<fetcher.Form action="/cart" className="absolute top-0 right-0" method="post">
+			<input name="variantId" type="hidden" value={variantId} />
+			<button
+				className={clsx(
+					'-m-2 inline-flex bg-white p-2 text-gray-400',
+					'hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-brand-primary focus:ring-offset-2',
+				)}
+				data-testid="remove-from-cart"
+				name={CART_INTENT}
+				type="submit"
+				value={CART_ACTIONS.REMOVE_ACTION}
+			>
+				<span className="sr-only">Remove</span>
+				<XMarkIcon aria-hidden="true" className="h-5 w-5" />
+			</button>
+		</fetcher.Form>
+	);
+}

--- a/apps/web/app/components/cart-content.tsx
+++ b/apps/web/app/components/cart-content.tsx
@@ -70,7 +70,18 @@ function FilledCart({
 	const navigation = useNavigation();
 	const { cart, linesDisplay } = result;
 
-	if (summaryPlacement === 'footer') {
+	const isFooter = summaryPlacement === 'footer';
+
+	const cartLinesSection = (
+		<section aria-labelledby="cart-heading" className={clsx(isFooter && 'min-h-0 flex-1 overflow-y-auto px-4')}>
+			<h2 className="sr-only" id="cart-heading">
+				Items in your shopping cart
+			</h2>
+			<CartLines linesDisplay={linesDisplay} result={result} />
+		</section>
+	);
+
+	if (isFooter) {
 		return (
 			<div className="@container/cart flex min-h-0 flex-1 flex-col">
 				{showHeading && (
@@ -80,14 +91,7 @@ function FilledCart({
 						</Heading>
 					</div>
 				)}
-
-				<section aria-labelledby="cart-heading" className="min-h-0 flex-1 overflow-y-auto px-4">
-					<h2 className="sr-only" id="cart-heading">
-						Items in your shopping cart
-					</h2>
-					<CartLines linesDisplay={linesDisplay} result={result} />
-				</section>
-
+				{cartLinesSection}
 				<CartSummary cart={cart} isPending={navigation.state !== 'idle'} placement="footer" />
 			</div>
 		);
@@ -101,13 +105,7 @@ function FilledCart({
 				</Heading>
 			)}
 			<div className="grid @5xl/cart:grid-cols-[minmax(0,1fr)_minmax(18rem,0.42fr)] grid-cols-1 items-start @5xl/cart:gap-12 gap-10">
-				<section aria-labelledby="cart-heading">
-					<h2 className="sr-only" id="cart-heading">
-						Items in your shopping cart
-					</h2>
-					<CartLines linesDisplay={linesDisplay} result={result} />
-				</section>
-
+				{cartLinesSection}
 				<CartSummary cart={cart} isPending={navigation.state !== 'idle'} placement="inline" />
 			</div>
 		</div>
@@ -245,16 +243,19 @@ function CartSummary({
 function LineItemPrice({ display }: { display: LineDisplay | undefined }) {
 	if (display == null) return null;
 
+	const compareAt = display.compareAt;
+	const showWasNow = display.showWasNow && compareAt != null;
+
 	return (
 		<div className="mt-1 flex flex-col gap-0.5 text-gray-900 text-sm">
-			{display.showWasNow && display.compareAt != null && (
+			{showWasNow && (
 				<del className="text-gray-500">
 					<span className="sr-only">Was </span>
-					{formatMoney(display.compareAt, 'AUD')}
+					{formatMoney(compareAt, 'AUD')}
 				</del>
 			)}
 			<span>
-				{display.showWasNow && display.compareAt != null && <span className="sr-only">Now </span>}
+				{showWasNow && <span className="sr-only">Now </span>}
 				{formatMoney(display.pricePerUnit, 'AUD')}
 			</span>
 			{display.discountLabels.map(({ label, amount }, index) => (

--- a/apps/web/app/components/cart-drawer.tsx
+++ b/apps/web/app/components/cart-drawer.tsx
@@ -1,0 +1,64 @@
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react';
+import { XMarkIcon } from '@heroicons/react/20/solid';
+import { useLoaderData, useSearchParams } from 'react-router';
+import { CART_DRAWER_PARAM } from '../lib/cart-actions';
+import type { loader } from '../root';
+import { CartContent } from './cart-content';
+
+export function CartDrawer() {
+	const { cartResult } = useLoaderData<typeof loader>();
+	const [searchParams, setSearchParams] = useSearchParams();
+
+	// The URL is the single source of truth for whether the drawer is open: the
+	// add-to-cart action redirects to `?cart=open`, and closing simply drops the
+	// param. No local state to keep in sync with the server.
+	const open = searchParams.has(CART_DRAWER_PARAM);
+
+	function close() {
+		setSearchParams(
+			(prev) => {
+				prev.delete(CART_DRAWER_PARAM);
+				return prev;
+			},
+			{ preventScrollReset: true, replace: true },
+		);
+	}
+
+	return (
+		<Dialog as="div" className="relative z-40" onClose={close} open={open} transition>
+			{/*
+			 * Entry/exit animation is CSS-driven, not JS-timed. `starting:` emits an
+			 * `@starting-style` rule so the browser guarantees the slid-out first frame
+			 * on mount — Headless UI's class-swap enter is otherwise skipped when the
+			 * drawer mounts inside a router navigation (the `?cart=open` redirect).
+			 * `data-closed:` defines the closed state for both enter and exit; under
+			 * reduced motion the slide is dropped to a plain opacity fade.
+			 */}
+			<DialogBackdrop
+				className="fixed inset-0 bg-black/25 starting:opacity-0 transition-opacity duration-300 ease-out data-closed:opacity-0"
+				transition
+			/>
+
+			<div className="fixed inset-0 z-40 flex justify-end">
+				<DialogPanel
+					className="flex h-full w-full max-w-md starting:translate-x-full transform-gpu flex-col overflow-hidden bg-white starting:opacity-0 shadow-xl transition duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] data-closed:translate-x-full data-closed:opacity-0 data-leave:duration-200 data-leave:ease-in motion-reduce:starting:translate-x-0 data-closed:motion-reduce:translate-x-0"
+					transition
+				>
+					<div className="flex shrink-0 items-center justify-between border-gray-200 border-b px-4 py-5">
+						<DialogTitle className="font-bold text-gray-900 text-lg">Cart</DialogTitle>
+						<button
+							className="-m-2 inline-flex items-center justify-center p-2 text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-brand-primary focus:ring-offset-2"
+							onClick={close}
+							type="button"
+						>
+							<span className="sr-only">Close cart</span>
+							<XMarkIcon aria-hidden="true" className="h-6 w-6" />
+						</button>
+					</div>
+
+					<CartContent result={cartResult} showHeading={false} summaryPlacement="footer" />
+				</DialogPanel>
+			</div>
+		</Dialog>
+	);
+}

--- a/apps/web/app/components/main-layout.tsx
+++ b/apps/web/app/components/main-layout.tsx
@@ -1,3 +1,4 @@
+import { CartDrawer } from './cart-drawer';
 import { Footer } from './footer';
 import { Header } from './header';
 
@@ -11,6 +12,7 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
 				Skip to content
 			</a>
 			<Header />
+			<CartDrawer />
 			<main className="mx-auto w-full max-w-7xl flex-1 scroll-mt-24 bg-white" id="main-content">
 				{children}
 			</main>

--- a/apps/web/app/lib/cart-actions.ts
+++ b/apps/web/app/lib/cart-actions.ts
@@ -6,6 +6,19 @@
  */
 export const CART_INTENT = 'intent';
 
+/** Search param that opens the cart drawer when present (e.g. `?cart=open`). */
+export const CART_DRAWER_PARAM = 'cart';
+
+/**
+ * Redirect target that opens the cart drawer for a product. Built from the
+ * route params rather than the action's `request.url`: in framework mode that
+ * URL is the single-fetch `.data` endpoint, so reconstructing from it produces
+ * a broken `/…​.data?cart=open` target that 404s.
+ */
+export function productCartOpenHref(theme: string, handle: string): string {
+	return `/${theme}/products/${handle}?${CART_DRAWER_PARAM}=open`;
+}
+
 export const CART_ACTIONS = {
 	CHECKOUT_ACTION: 'checkout',
 	DECREMENT_ACTION: 'decrement',

--- a/apps/web/app/lib/cart-actions.unit.test.ts
+++ b/apps/web/app/lib/cart-actions.unit.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { productCartOpenHref } from './cart-actions';
+
+describe('productCartOpenHref', () => {
+	it('builds the canonical product path with the drawer-open param', () => {
+		expect(productCartOpenHref('ladies', 'ibkul-tulip-sleeve-polo-alexis-turquoise')).toBe(
+			'/ladies/products/ibkul-tulip-sleeve-polo-alexis-turquoise?cart=open',
+		);
+	});
+
+	it('never produces a single-fetch `.data` target', () => {
+		// Regression: the action redirect used to be rebuilt from `request.url`,
+		// which in framework mode is the `.data` endpoint, so add-to-cart 404'd.
+		const href = productCartOpenHref('mens', 'some-handle');
+		expect(href).not.toContain('.data');
+		expect(href.startsWith('/mens/products/')).toBe(true);
+	});
+});

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -8,6 +8,7 @@ import { useEffect } from 'react';
 import type { LinksFunction, LoaderFunctionArgs, MetaFunction, MiddlewareFunction } from 'react-router';
 import {
 	createContext,
+	data,
 	isRouteErrorResponse,
 	Links,
 	Meta,
@@ -85,6 +86,10 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
 		storefront.request(SHOP_QUERY),
 		getMainNavigation(),
 	]);
+	const cartResult =
+		view.type === 'success'
+			? { cart: view.cart, linesDisplay: view.linesDisplay, type: view.type }
+			: { type: view.type };
 
 	// Calculate total quantity by summing all reconciled line quantities.
 	let cartCount = 0;
@@ -94,11 +99,19 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
 		}
 	}
 
-	return {
-		cartCount,
-		mainNavigation,
-		shop,
-	};
+	return data(
+		{
+			cartCount,
+			cartResult,
+			mainNavigation,
+			shop,
+		},
+		{
+			headers: {
+				'Set-Cookie': await session.commitSession(),
+			},
+		},
+	);
 }
 
 export const meta: MetaFunction<typeof loader> = () => {

--- a/apps/web/app/routes/$theme.products.$handle.tsx
+++ b/apps/web/app/routes/$theme.products.$handle.tsx
@@ -14,8 +14,7 @@ import { Image } from '@unpic/react';
 import { clsx } from 'clsx';
 import { useRef, useState } from 'react';
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, Form, data as json, useActionData, useFetcher, useLoaderData } from 'react-router';
-import invariant from 'tiny-invariant';
+import { Form, data as json, redirect, useActionData, useFetcher, useLoaderData } from 'react-router';
 import { z } from 'zod';
 import { Button, ButtonLink } from '../components/design-system/button';
 import { FieldMessage } from '../components/design-system/field';
@@ -25,13 +24,14 @@ import { PayPalMessages } from '../components/paypal';
 import { CACHE_NONE, routeHeaders } from '../lib/cache';
 import type { CartItem } from '../lib/cart';
 import { getSession } from '../lib/cart';
+import { productCartOpenHref } from '../lib/cart-actions';
 import { createCart } from '../lib/cart-model';
 import { notFound } from '../lib/errors.server';
 import { focusFirstInvalidField } from '../lib/focus-first-invalid-field';
 import { useAppForm } from '../lib/form-context';
 import { formatMoney } from '../lib/format-money';
 import { getSizingChart } from '../lib/get-sizing-chart';
-import { getSeoMeta } from '../seo';
+import { getSeoMeta, seoConfig } from '../seo';
 import { storefrontContext } from '../root';
 
 const productSchema = z.object({
@@ -153,8 +153,9 @@ export async function loader({ context, params, request }: LoaderFunctionArgs) {
 	notFound();
 }
 
-export async function action({ context, request }: ActionFunctionArgs): Promise<ProductActionResult> {
+export async function action({ context, params, request }: ActionFunctionArgs): Promise<ProductActionResult> {
 	const [formData, session] = await Promise.all([request.formData(), getSession(request)]);
+	const { theme, handle } = productSchema.parse(params);
 
 	try {
 		// Get the default variant ID from the form data or use empty string
@@ -168,15 +169,18 @@ export async function action({ context, request }: ActionFunctionArgs): Promise<
 		const cart = createCart({ storefront, session });
 		await cart.add(variantId, 1);
 
-		return data(
-			{ type: 'success' },
-			{
-				headers: {
-					'Set-Cookie': await session.commitSession(),
-				},
+		// Open the cart drawer by putting the state in the URL. The fetcher follows
+		// this redirect, so `?cart=open` becomes the source of truth for the drawer.
+		throw redirect(productCartOpenHref(theme, handle), {
+			headers: {
+				'Set-Cookie': await session.commitSession(),
 			},
-		);
+		});
 	} catch (err) {
+		// Intentional thrown Responses (e.g. the `?cart=open` redirect above) must
+		// propagate untouched rather than being treated as errors.
+		if (err instanceof Response) throw err;
+
 		if (err instanceof ServerValidateError) {
 			return json(
 				{ type: 'error', formState: err.formState },
@@ -209,7 +213,10 @@ export async function action({ context, request }: ActionFunctionArgs): Promise<
 }
 
 export const meta: MetaFunction<typeof loader> = ({ loaderData }) => {
-	invariant(loaderData, 'Expected data for meta function');
+	// `loaderData` can be undefined when the route is rendered through its error
+	// boundary or mid-revalidation, so fall back to the site defaults rather than
+	// throwing (a throw here surfaces as a full-page "Invariant failed" crash).
+	if (!loaderData) return getSeoMeta(seoConfig);
 	return getSeoMeta({
 		description: loaderData.product.description,
 		title: loaderData.product.title,

--- a/apps/web/app/routes/cart.tsx
+++ b/apps/web/app/routes/cart.tsx
@@ -1,22 +1,14 @@
-import { CheckIcon, ClockIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import { captureException } from '@sentry/react-router';
 import type { ServerFormState } from '@tanstack/react-form-remix';
 import { createServerValidate, formOptions, initialFormState, ServerValidateError } from '@tanstack/react-form-remix';
-import { Image } from '@unpic/react';
-import { clsx } from 'clsx';
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { data, Form, Link, redirect, useFetcher, useLoaderData, useNavigation } from 'react-router';
+import { data, redirect, useLoaderData } from 'react-router';
 import { z } from 'zod';
-import { QuantityPicker } from '../components/cart/quantity-picker';
-import { Button, ButtonLink } from '../components/design-system/button';
-import { Heading } from '../components/design-system/heading';
-import { PayPalMessages } from '../components/paypal';
+import { CartContent } from '../components/cart-content';
 import { CACHE_NONE, routeHeaders } from '../lib/cache';
-import { getSession } from '../lib/cart';
 import { CART_ACTIONS, CART_INTENT } from '../lib/cart-actions';
+import { getSession } from '../lib/cart';
 import { createCart } from '../lib/cart-model';
-import { formatMoney } from '../lib/format-money';
-import type { LineDisplay } from '../lib/line-display';
 import { storefrontContext } from '../root';
 import { getSeoMeta } from '../seo';
 
@@ -254,198 +246,12 @@ export const headers = routeHeaders;
 
 export default function CartPage() {
 	const cartResult = useLoaderData<typeof loader>();
-	const navigation = useNavigation();
-
-	// Handle null case or empty cart
-	if (['empty', 'error'].includes(cartResult.type) || !cartResult.cart || cartResult.cart.lines.edges.length === 0) {
-		return (
-			<div className="bg-white">
-				<div className="mx-auto max-w-2xl px-4 pt-16 pb-24 text-center sm:px-6 lg:max-w-7xl lg:px-8">
-					<div className="flex flex-col gap-6">
-						<Heading headingElement="h1" size="2">
-							Shopping Cart
-						</Heading>
-						<h2>Your cart is currently empty.</h2>
-						<span>
-							<ButtonLink href="/" variant="neutral">
-								Continue shopping
-							</ButtonLink>
-						</span>
-					</div>
-				</div>
-			</div>
-		);
-	}
-
-	// Now we know cartResult exists and has a cart property; linesDisplay is set when type is success
-	const { cart, linesDisplay } = cartResult;
 
 	return (
 		<div className="bg-white">
-			<div className="mx-auto max-w-2xl px-4 pt-16 pb-24 sm:px-6 lg:max-w-7xl lg:px-8">
-				<Heading headingElement="h1" size="2">
-					Shopping Cart
-				</Heading>
-				<div className="mt-12 lg:grid lg:grid-cols-12 lg:items-start lg:gap-x-12 xl:gap-x-16">
-					<section aria-labelledby="cart-heading" className="lg:col-span-7">
-						<h2 className="sr-only" id="cart-heading">
-							Items in your shopping cart
-						</h2>
-
-						{Array.isArray(cart.lines.edges) && linesDisplay ? (
-							<ul className="divide-y divide-gray-200 border-gray-200 border-t border-b" role="list">
-								{cart.lines.edges.map(({ node }, index) => {
-									const theme = node.merchandise.product.tags.includes('ladies') ? 'ladies' : 'mens';
-									return (
-										<li className="flex py-6 sm:py-10" data-theme={theme} key={node.id}>
-											<div className="shrink-0">
-												{node.merchandise.image?.url ? (
-													<Image
-														alt={node.merchandise.image.altText ?? ''}
-														className="h-24 w-24 object-contain object-center sm:h-48 sm:w-48"
-														height={192}
-														layout="constrained"
-														priority={false}
-														src={node.merchandise.image.url}
-														width={192}
-													/>
-												) : (
-													<span className="block h-24 w-24 bg-gray-200 sm:h-48 sm:w-48" />
-												)}
-											</div>
-
-											<div className="ml-4 flex flex-1 flex-col justify-between sm:ml-6">
-												<div className="relative pr-9 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:pr-0">
-													<div>
-														<div className="flex justify-between">
-															<h3 className="text-sm">
-																<Link
-																	className="text-gray-700 hover:text-gray-800"
-																	prefetch="intent"
-																	to={`/${theme}/products/${node.merchandise.product.handle}`}
-																>
-																	{node.merchandise.product.title}
-																</Link>
-															</h3>
-														</div>
-														{node.merchandise.title !== 'Default Title' && (
-															<div className="mt-1 flex text-sm">
-																<p className="text-gray-500">{node.merchandise.title}</p>
-															</div>
-														)}
-														<LineItemPrice display={linesDisplay[index]} />
-													</div>
-
-													<div className="mt-4 sm:mt-0 sm:pr-9">
-														<QuantityPicker
-															quantity={node.quantity}
-															quantityAvailable={node.merchandise.quantityAvailable ?? 0}
-															variantId={node.merchandise.id}
-														/>
-														<RemoveFromCart variantId={node.merchandise.id} />
-													</div>
-												</div>
-
-												<p className="mt-4 flex space-x-2 text-gray-700 text-sm">
-													{node.merchandise.currentlyNotInStock ? (
-														<ClockIcon aria-hidden="true" className="h-5 w-5 shrink-0 text-gray-300" />
-													) : (
-														<CheckIcon aria-hidden="true" className="h-5 w-5 shrink-0 text-green-500" />
-													)}
-													<span>{node.merchandise.currentlyNotInStock ? 'Out of stock' : 'In stock'}</span>
-												</p>
-											</div>
-										</li>
-									);
-								})}
-							</ul>
-						) : null}
-					</section>
-
-					{/* Order summary */}
-					<Form
-						aria-labelledby="summary-heading"
-						className="mt-16 flex flex-col gap-6 bg-gray-50 px-4 py-6 sm:p-6 lg:col-span-5 lg:mt-0 lg:p-8"
-						method="post"
-					>
-						<h2 className="text-gray-900 text-lg" id="summary-heading">
-							Order summary
-						</h2>
-
-						<dl className="mt-6 space-y-4">
-							<div className="flex items-center justify-between">
-								<dt className="text-gray-600 text-sm">Subtotal</dt>
-								<dd className="text-gray-900 text-sm">{formatMoney(cart.cost.subtotalAmount)}</dd>
-							</div>
-						</dl>
-						<PayPalMessages amount={Number(cart.cost.subtotalAmount.amount || 0)} placement="cart" />
-
-						<p className="text-gray-600 text-sm">Taxes and shipping are calculated at checkout</p>
-
-						{cart.checkoutUrl && (
-							<>
-								<input name="checkoutUrl" type="hidden" value={cart.checkoutUrl} />
-								<Button
-									disabled={navigation.state !== 'idle'}
-									name={CART_INTENT}
-									type="submit"
-									value={CART_ACTIONS.CHECKOUT_ACTION}
-									variant="neutral"
-								>
-									Checkout
-								</Button>
-							</>
-						)}
-					</Form>
-				</div>
+			<div className="mx-auto max-w-2xl px-4 pt-16 pb-24 lg:max-w-7xl">
+				<CartContent result={cartResult} />
 			</div>
 		</div>
-	);
-}
-
-function LineItemPrice({ display }: { display: LineDisplay | undefined }) {
-	if (display == null) return null;
-	return (
-		<div className="mt-1 flex flex-col gap-0.5 text-gray-900 text-sm">
-			{display.showWasNow && display.compareAt != null && (
-				<del className="text-gray-500">
-					<span className="sr-only">Was </span>
-					{formatMoney(display.compareAt, 'AUD')}
-				</del>
-			)}
-			<span>
-				{display.showWasNow && display.compareAt != null && <span className="sr-only">Now </span>}
-				{formatMoney(display.pricePerUnit, 'AUD')}
-			</span>
-			{display.discountLabels.map(({ label, amount }, index) => (
-				<span className="text-gray-600 text-xs" key={index}>
-					{label}
-					{amount != null && ` (-${formatMoney(amount, 'AUD')})`}
-				</span>
-			))}
-		</div>
-	);
-}
-
-function RemoveFromCart({ variantId }: { variantId: string }) {
-	const fetcher = useFetcher();
-
-	return (
-		<fetcher.Form className="absolute top-0 right-0" method="post">
-			<input name="variantId" type="hidden" value={variantId} />
-			<button
-				className={clsx(
-					'-m-2 inline-flex bg-white p-2 text-gray-400',
-					'hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-brand-primary focus:ring-offset-2',
-				)}
-				data-testid="remove-from-cart"
-				name={CART_INTENT}
-				type="submit"
-				value={CART_ACTIONS.REMOVE_ACTION}
-			>
-				<span className="sr-only">Remove</span>
-				<XMarkIcon aria-hidden="true" className="h-5 w-5" />
-			</button>
-		</fetcher.Form>
 	);
 }

--- a/packages/playwright/e2e/search-checkout-flow.spec.ts
+++ b/packages/playwright/e2e/search-checkout-flow.spec.ts
@@ -5,15 +5,17 @@ import invariant from 'tiny-invariant';
 const CHECKOUT_URL_REGEX = /^https:\/\/golfladiesfirst\.myshopify\.com\/checkouts\//;
 const CART_LINK_REGEX = /items in cart, view bag/;
 const ADD_TO_CART_BUTTON_REGEX = /add to cart|adding/i;
-const ADDING_BUTTON_REGEX = /adding/i;
 
 async function addToCart(page: Page) {
-	const addToCartButton = page.getByRole('button', { name: ADD_TO_CART_BUTTON_REGEX });
-	await addToCartButton.click();
-	await expect(addToCartButton).toBeDisabled();
-	await expect(addToCartButton).toHaveText(ADDING_BUTTON_REGEX);
-	await expect(addToCartButton).toBeEnabled();
-	await expect(addToCartButton).toHaveText('Add to cart');
+	await page.getByRole('button', { name: ADD_TO_CART_BUTTON_REGEX }).click();
+
+	// Adding redirects to `?cart=open`, which opens the cart drawer over the page.
+	// Its appearance confirms the item was added; close it so the header and the
+	// Add to cart button stay clickable for the next step.
+	const closeDrawer = page.getByRole('button', { name: 'Close cart' });
+	await expect(closeDrawer).toBeVisible();
+	await closeDrawer.click();
+	await expect(closeDrawer).toBeHidden();
 }
 
 test.describe('Search and checkout flow', () => {

--- a/packages/playwright/e2e/search-checkout-flow.spec.ts
+++ b/packages/playwright/e2e/search-checkout-flow.spec.ts
@@ -14,6 +14,7 @@ async function addToCart(page: Page) {
 	// Add to cart button stay clickable for the next step.
 	const closeDrawer = page.getByRole('button', { name: 'Close cart' });
 	await expect(closeDrawer).toBeVisible();
+	await expect(page.getByTestId('quantity-display')).toBeVisible();
 	await closeDrawer.click();
 	await expect(closeDrawer).toBeHidden();
 }


### PR DESCRIPTION
## What changed

This reworks how the cart drawer opens. It builds on the Storefront seam merged in #325.

The drawer's open state now lives in the `?cart=open` search param. Adding an item redirects to the product page with that param, and closing the drawer removes it, so the URL is the source of truth. The old version read a server-side flash ("cart drawer intent") once through the root loader and mirrored it into local component state with `useState` and a `useEffect`, which this removes.

Two related changes came with it:

- The cart UI moved into a shared `CartContent` component, used by both the drawer and the `/cart` route.
- The product action redirects to `/$theme/products/$handle?cart=open` built from route params rather than `request.url`. In framework mode the action request arrives at the `.data` endpoint, so a redirect rebuilt from `request.url` pointed at `.../handle.data?cart=open` and 404'd.

## Entrance animation

The drawer mounts as the result of a router navigation. Headless UI runs its enter transition from JavaScript (apply the start classes, force a reflow, apply the end classes), and the browser skips that first frame when the mount lands inside the navigation commit. So the drawer slid out on close but appeared instantly on open.

Entry and exit now run in CSS. The panel uses Headless UI's `transition` prop with `data-closed:` for the closed state, plus Tailwind's `starting:` variant, which compiles to `@starting-style`. That gives the browser a guaranteed slid-out, transparent first frame no matter when React inserts the element. Under `prefers-reduced-motion: reduce` the slide drops to a plain opacity fade.

## Testing

- `cart-actions.unit.test.ts` pins the redirect path and asserts it never contains `.data`.
- Checked in a browser by sampling the panel's `translate` and `opacity` per frame. It slides in and out under normal motion and fades only under reduced motion. After add-to-cart the URL reads `?cart=open`.
- `pnpm check:types`, `pnpm check:lint`, and `pnpm test:unit` (100 tests) pass.
