### PR TITLE
Add RadioGroup field component

### DIFF
--- a/apps/web/app/components/design-system/radio-group.tsx
+++ b/apps/web/app/components/design-system/radio-group.tsx
@@ -1,0 +1,89 @@
+import { clsx } from 'clsx';
+import { mergeIds } from '../../lib/merge-ids';
+import { FieldMessage, useFieldIds } from './field/field';
+
+type RadioOption = { label: string; value: string };
+
+function toOption(option: RadioOption | string): RadioOption {
+	return typeof option === 'string' ? { label: option, value: option } : option;
+}
+
+export type RadioGroupProps = {
+	/** Additional classes for the fieldset (e.g. grid placement). */
+	className?: string;
+	/** Provide additional information that will aid user input. */
+	description?: string;
+	disabled?: boolean;
+	id?: string;
+	/** Labels the group of options. */
+	legend: string;
+	/** Provide a message, informing the user about changes in state. */
+	message?: string;
+	name?: string;
+	onBlur?: React.FocusEventHandler<HTMLInputElement>;
+	onChange?: React.ChangeEventHandler<HTMLInputElement>;
+	options: ReadonlyArray<RadioOption | string>;
+	required?: boolean;
+	tone?: 'critical' | 'neutral' | 'positive';
+	value?: string;
+};
+
+export function RadioGroup({
+	className,
+	description,
+	disabled = false,
+	id,
+	legend,
+	message,
+	name,
+	onBlur,
+	onChange,
+	options,
+	required,
+	tone = 'critical',
+	value,
+}: RadioGroupProps) {
+	const { descriptionId, inputId, messageId } = useFieldIds(id);
+	const invalid = Boolean(message && tone === 'critical');
+
+	return (
+		<fieldset
+			aria-describedby={mergeIds(message && messageId, description && descriptionId)}
+			aria-invalid={invalid || undefined}
+			className={clsx('flex flex-col gap-4', className)}
+		>
+			<legend className="text-gray-700 text-sm">{legend}</legend>
+			{description && (
+				<span className="text-gray-600" id={descriptionId}>
+					{description}
+				</span>
+			)}
+			<div className="mt-4 space-y-4 sm:flex sm:items-center sm:space-x-10 sm:space-y-0">
+				{options.map((option) => {
+					const { label, value: optionValue } = toOption(option);
+					const optionId = `${inputId}-${optionValue}`;
+					return (
+						<div className="flex items-center gap-3" key={optionValue}>
+							<input
+								checked={value === optionValue}
+								className="h-5 w-5 border-gray-300 text-brand-primary focus:ring-brand-light"
+								disabled={disabled}
+								id={optionId}
+								name={name}
+								onBlur={onBlur}
+								onChange={onChange}
+								required={required}
+								type="radio"
+								value={optionValue}
+							/>
+							<label className="block font-medium text-gray-700 text-sm" htmlFor={optionId}>
+								{label}
+							</label>
+						</div>
+					);
+				})}
+			</div>
+			{message && <FieldMessage id={messageId} message={message} tone={tone} />}
+		</fieldset>
+	);
+}

--- a/apps/web/app/components/newsletter/form.tsx
+++ b/apps/web/app/components/newsletter/form.tsx
@@ -7,7 +7,6 @@ import { Turnstile } from 'react-turnstile';
 import { focusFirstInvalidField } from '../../lib/focus-first-invalid-field';
 import { useAppForm } from '../../lib/form-context';
 import { getErrorMessage, getFormErrors, hasFieldErrors } from '../../lib/form-utils';
-import { isFieldRequired } from '../../lib/get-required-fields';
 import { useClientOnlyMount } from '../../lib/use-client-only-mount';
 import { Button } from '../design-system/button';
 import { FieldMessage } from '../design-system/field';
@@ -117,43 +116,13 @@ export function NewsletterSignup() {
 						</form.AppField>
 
 						<form.AppField name="gender">
-							{(field) => {
-								const errorMessage = field.state.meta.errors[0]?.message;
-								const errorMessageId = `${field.name}-error`;
-								const required = isFieldRequired(field.form, field.name);
-
-								const fieldsetA11yProps = {
-									'aria-describedby': errorMessage ? errorMessageId : undefined,
-									'aria-invalid': errorMessage ? true : undefined,
-									'aria-required': required || undefined,
-								};
-
-								return (
-									<fieldset {...fieldsetA11yProps} className="flex flex-col gap-4 sm:col-span-4">
-										<legend className="text-gray-700 text-sm">Which list would you like to sign up to?</legend>
-										<div className="mt-4 space-y-4 sm:flex sm:items-center sm:space-x-10 sm:space-y-0">
-											{(['Ladies', 'Mens'] as const).map((option) => (
-												<div className="flex items-center gap-3" key={option}>
-													<input
-														className="h-5 w-5 border-gray-300 text-brand-primary focus:ring-brand-light"
-														id={option}
-														name={field.name}
-														onBlur={field.handleBlur}
-														onChange={(event) => field.handleChange(event.target.value)}
-														required={required}
-														type="radio"
-														value={option}
-													/>
-													<label className="block font-medium text-gray-700 text-sm" htmlFor={option}>
-														{option}
-													</label>
-												</div>
-											))}
-										</div>
-										{errorMessage && <FieldMessage id={errorMessageId} message={errorMessage} tone="critical" />}
-									</fieldset>
-								);
-							}}
+							{(field) => (
+								<field.RadioGroup
+									className="sm:col-span-4"
+									legend="Which list would you like to sign up to?"
+									options={['Ladies', 'Mens']}
+								/>
+							)}
 						</form.AppField>
 
 						<form.AppField name="token">

--- a/apps/web/app/lib/form-context.browser.test.tsx
+++ b/apps/web/app/lib/form-context.browser.test.tsx
@@ -5,9 +5,10 @@ import { useAppForm } from './form-context';
 
 function TestForm() {
 	const form = useAppForm({
-		defaultValues: { name: '', token: '' },
+		defaultValues: { gender: '', name: '', token: '' },
 		validators: {
 			onSubmit: z.object({
+				gender: z.string().min(1),
 				name: z.string().min(1),
 				token: z.string(),
 			}),
@@ -18,6 +19,9 @@ function TestForm() {
 		<form>
 			<form.AppField name="name">{(field) => <field.TextField label="Name" />}</form.AppField>
 			<form.AppField name="token">{(field) => <field.TextField label="Token" />}</form.AppField>
+			<form.AppField name="gender">
+				{(field) => <field.RadioGroup legend="Gender" options={['Ladies', 'Mens']} />}
+			</form.AppField>
 		</form>
 	);
 }
@@ -39,5 +43,14 @@ describe('useAppForm required derivation (browser)', () => {
 
 		await expect.element(token).not.toBeRequired();
 		expect(token.element().hasAttribute('aria-required')).toBe(false);
+	});
+
+	it('derives required for a RadioGroup field from the schema', async () => {
+		const screen = await render(<TestForm />);
+
+		// Required state is conveyed natively on the radio inputs (valid for a
+		// fieldset/group, unlike aria-required which the role does not support).
+		await expect.element(screen.getByRole('radio', { name: 'Ladies' })).toBeRequired();
+		await expect.element(screen.getByRole('radio', { name: 'Mens' })).toBeRequired();
 	});
 });

--- a/apps/web/app/lib/form-context.tsx
+++ b/apps/web/app/lib/form-context.tsx
@@ -5,6 +5,8 @@ import type { FieldProps } from '../components/design-system/field';
 import { Field } from '../components/design-system/field';
 import type { InlineFieldProps } from '../components/design-system/field/inline-field';
 import { InlineField } from '../components/design-system/field/inline-field';
+import type { RadioGroupProps } from '../components/design-system/radio-group';
+import { RadioGroup } from '../components/design-system/radio-group';
 import type { TextAreaProps } from '../components/design-system/text-area';
 import { TextArea } from '../components/design-system/text-area';
 import type { TextInputProps } from '../components/design-system/text-input';
@@ -24,6 +26,8 @@ type TextAreaFieldProps = Omit<TextAreaProps, 'checked' | 'name' | 'onBlur' | 'o
 type CheckboxFieldProps = Omit<CheckboxProps, 'checked' | 'name' | 'onBlur' | 'onChange' | 'value'> & {
 	label: React.ReactNode;
 };
+
+type RadioGroupFieldProps = Omit<RadioGroupProps, 'message' | 'name' | 'onBlur' | 'onChange' | 'tone' | 'value'>;
 
 function FormFieldWrapper(props: FieldProps) {
 	const field = useFieldContext<string>();
@@ -96,11 +100,30 @@ function FormCheckbox(props: CheckboxFieldProps) {
 	);
 }
 
+function FormRadioGroup(props: RadioGroupFieldProps) {
+	const field = useFieldContext<string>();
+	const errorMessage = field.state.meta.errors[0]?.message;
+	const { required, ...rest } = props;
+
+	return (
+		<RadioGroup
+			{...rest}
+			message={errorMessage}
+			name={field.name}
+			onBlur={field.handleBlur}
+			onChange={(event) => field.handleChange(event.target.value)}
+			required={required ?? isFieldRequired(field.form, field.name)}
+			value={field.state.value}
+		/>
+	);
+}
+
 export const { useAppForm } = createFormHook({
 	fieldComponents: {
 		Checkbox: FormCheckbox,
 		FormField: FormFieldWrapper,
 		InlineFormField: InlineFormFieldWrapper,
+		RadioGroup: FormRadioGroup,
 		TextArea: FormTextArea,
 		TextField: FormTextField,
 	},


### PR DESCRIPTION
## What

Adds a `RadioGroup` design-system component and a `FormRadioGroup` field wrapper, and switches the newsletter gender field to use it.

Previously the gender radio group was hand-rolled `<fieldset>` + `<input type="radio">` markup that manually called `isFieldRequired` and set `aria-required`/`required` itself — the one field that bypassed the form primitives. It now behaves like every other field: `required` is derived from the form's Zod schema with no per-call-site wiring.

## Details

- `app/components/design-system/radio-group.tsx` — new component: fieldset + legend, options, error message via `FieldMessage`, `aria-describedby`/`aria-invalid` wiring, controlled radios.
- `app/lib/form-context.tsx` — registers `FormRadioGroup` in `fieldComponents`, deriving `required` from the schema (with an explicit-prop escape hatch), like the existing text/checkbox wrappers.
- `app/components/newsletter/form.tsx` — gender field replaced with `<field.RadioGroup legend=… options={['Ladies', 'Mens']} />`; drops the manual wiring and the now-unused `isFieldRequired` import.
- Required state is conveyed via native `required` on the radio inputs (`aria-required` is not valid on a fieldset/`group` role).

## Verification

- `check:types`, `check:lint`, `check:format` pass
- `test:unit` 100 passed; `test:browser` 18 passed (incl. a new test asserting the RadioGroup derives `required` from the schema)
- Production build clean; SSR bundle loads