### PR TITLE
Fix Sentry release var and source map handling for Workers

### DIFF
--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -6,7 +6,6 @@
 			"dependsOn": ["@glfonline/sanity-client#build", "@glfonline/shopify-client#build"],
 			"env": [
 				"AKISMET_API_KEY",
-				"COMMIT_REF",
 				"DEV",
 				"ENABLE_EXPERIMENTAL_COREPACK",
 				"ENCRYPTION_KEY",
@@ -19,7 +18,8 @@
 				"SENTRY_DSN",
 				"SENTRY_ORG",
 				"SENTRY_PROJECT",
-				"TURNSTILE_SECRET_KEY"
+				"TURNSTILE_SECRET_KEY",
+				"WORKERS_CI_COMMIT_SHA"
 			],
 			"outputs": [".cache/**", ".wrangler/**", "build/**", "public/build/**"]
 		},

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -17,13 +17,17 @@ const sentryConfig: SentryReactRouterBuildOptions = {
 
 	unstable_sentryVitePluginOptions: {
 		release: {
-			name: process.env.COMMIT_REF,
+			name: process.env.WORKERS_CI_COMMIT_SHA,
 			setCommits: {
 				auto: true,
 			},
 		},
 		sourcemaps: {
-			filesToDeleteAfterUpload: ['./build/**/*.map'],
+			// Client maps are deleted so they aren't publicly served from the assets
+			// directory. Server maps are kept: they're inside the Worker bundle (never
+			// public), and `upload_source_maps` in wrangler.jsonc needs them present or
+			// `wrangler deploy` fails on the dangling sourceMappingURL reference.
+			filesToDeleteAfterUpload: ['./build/client/**/*.map'],
 		},
 	},
 };


### PR DESCRIPTION
Two follow-ups to the Cloudflare port (#346), both found while deploying to production.

## 1. `COMMIT_REF` → `WORKERS_CI_COMMIT_SHA`

`COMMIT_REF` was a **Netlify**-provided build variable and is never set on Cloudflare, so the Sentry release name was `undefined` and `sentry-cli` silently fell back to git auto-detection. Workers Builds provides `WORKERS_CI_COMMIT_SHA` (alongside `WORKERS_CI_BRANCH` and `WORKERS_CI`).

Not broken — auto-detection works, and will keep working in Workers Builds since it clones the repo — but the config was misleading. `apps/web/turbo.json` updated to match.

## 2. Source maps: `wrangler deploy` was failing outright

`wrangler.jsonc` sets `upload_source_maps: true`, but Sentry's `filesToDeleteAfterUpload: ['./build/**/*.map']` deleted every map after uploading — including the server ones. That left a dangling `sourceMappingURL` in `build/server/index.js`, and wrangler refused to deploy:

```
✘ [ERROR] Invalid source map path in .../build/server/index.js:
  .../build/server/index.js.map does not exist.
```

Narrowed to `['./build/client/**/*.map']`:

- **Client maps deleted** — they'd otherwise be publicly served from the assets directory.
- **Server maps kept** — they live inside the Worker bundle, are never publicly served, and Cloudflare's observability needs them for readable stack traces. Sentry gets both either way.

## Verified in production

Deployed as version `91c70f00-c265-45c4-ab3c-2e68728229ff`:

- All client source maps now return **404** (they were 200 — the previous deploy had been built without `SENTRY_AUTH_TOKEN`, publishing the client source and leaving Sentry with no maps to symbolicate)
- Every asset referenced by the live HTML returns 200
- Routes, real 404, and the cart round-trip (add → session cookie → line item renders) all pass
- Apex redirect intact with query strings preserved: `glfonline.com.au/ladies?gclid=X` → 301 → `www.glfonline.com.au/ladies?gclid=X`

## Known issue, not fixed here

`setCommits: { auto: true }` fails during the build:

```
sentry-cli releases set-commits <sha> --auto
error: API request failed
  sentry reported an error: You do not have permission to perform this action. (403)
```

Source map upload and release creation both succeed — only commit association fails, so Sentry won't show suspect commits. Either the auth token lacks the scope or the GitHub repo integration isn't connected on the Sentry org. Needs a decision (broaden the token vs drop the option), so left alone rather than silently removed.