### PR TITLE
Stop Sentry release commit association

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -18,9 +18,6 @@ const sentryConfig: SentryReactRouterBuildOptions = {
 	unstable_sentryVitePluginOptions: {
 		release: {
 			name: process.env.WORKERS_CI_COMMIT_SHA,
-			setCommits: {
-				auto: true,
-			},
 		},
 		sourcemaps: {
 			// Client maps are deleted so they aren't publicly served from the assets


### PR DESCRIPTION
## What changed

Removes automatic Git commit association from the Sentry release upload configuration. Releases keep their Cloudflare commit SHA and source maps continue to upload.

## Why

Cloudflare production build `a18db1a2` reached Sentry but failed when `sentry-cli releases set-commits --auto` returned HTTP 403. Commit association is optional and should not block deployments.

## Validation

- `env -u SENTRY_AUTH_TOKEN pnpm --dir apps/web build`
- `pnpm --filter @glfonline/web check:types`
- `git diff --check`