### PR TITLE
Cache anonymous collection pages behind a Workers gateway

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -50,6 +50,13 @@ jobs:
       - name: 📥 Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
 
+      # The dev server the tests run against imports the built workspace
+      # packages. Building them here rather than letting `dev:web` race its own
+      # `tsdown --watch` tasks keeps the server's startup within Playwright's
+      # `webServer` timeout on a cold runner.
+      - name: 🏗️ Build workspace packages
+        run: pnpm run build:packages
+
       - name: 🎭 Run Playwright tests
         run: pnpm run test:e2e
 

--- a/apps/web/app/lib/anonymous-cache.ts
+++ b/apps/web/app/lib/anonymous-cache.ts
@@ -1,0 +1,36 @@
+import { hasSessionCookie } from './session-cookie';
+
+/**
+ * Matches a collection page path: a theme, `/collections/`, and a single
+ * collection handle, with an optional trailing slash.
+ *
+ * The handle segment excludes dots so React Router's single-fetch data URLs
+ * (`/ladies/collections/apparel.data`) are not treated as collection pages.
+ * Those are deliberately left uncached here: the `headers` export's behaviour
+ * for single-fetch responses has not been verified, and a response with no
+ * explicit cache header would fall into RFC 9111 heuristic caching.
+ */
+const COLLECTION_PATH_PATTERN = /^\/(?:ladies|mens)\/collections\/[^/.]+\/?$/;
+
+/**
+ * Whether this request may be served from the shared, cookie-less Workers cache.
+ *
+ * Query strings are allowed through: filter, sort and pagination params are part
+ * of the cache key, so each variant is cached separately.
+ */
+export function isAnonymousCollectionRequest(request: Request): boolean {
+	if (request.method !== 'GET' && request.method !== 'HEAD') return false;
+	if (hasSessionCookie(request.headers.get('Cookie'))) return false;
+	return COLLECTION_PATH_PATTERN.test(new URL(request.url).pathname);
+}
+
+/**
+ * Strips the `Cookie` header so the cached entrypoint cannot produce a
+ * cookie-dependent response. The Workers Caching key does not include cookies,
+ * so anything derived from them could be served to the wrong visitor.
+ */
+export function toAnonymousRequest(request: Request): Request {
+	const anonymousRequest = new Request(request);
+	anonymousRequest.headers.delete('Cookie');
+	return anonymousRequest;
+}

--- a/apps/web/app/lib/anonymous-cache.ts
+++ b/apps/web/app/lib/anonymous-cache.ts
@@ -1,36 +1,21 @@
 import { hasSessionCookie } from './session-cookie';
 
-/**
- * Matches a collection page path: a theme, `/collections/`, and a single
- * collection handle, with an optional trailing slash.
- *
- * The handle segment excludes dots so React Router's single-fetch data URLs
- * (`/ladies/collections/apparel.data`) are not treated as collection pages.
- * Those are deliberately left uncached here: the `headers` export's behaviour
- * for single-fetch responses has not been verified, and a response with no
- * explicit cache header would fall into RFC 9111 heuristic caching.
- */
-const COLLECTION_PATH_PATTERN = /^\/(?:ladies|mens)\/collections\/[^/.]+\/?$/;
-
-/**
- * Whether this request may be served from the shared, cookie-less Workers cache.
- *
- * Query strings are allowed through: filter, sort and pagination params are part
- * of the cache key, so each variant is cached separately.
- */
+/** Whether this request can use the anonymous collection cache. */
 export function isAnonymousCollectionRequest(request: Request): boolean {
 	if (request.method !== 'GET' && request.method !== 'HEAD') return false;
 	if (hasSessionCookie(request.headers.get('Cookie'))) return false;
 	return COLLECTION_PATH_PATTERN.test(new URL(request.url).pathname);
 }
 
-/**
- * Strips the `Cookie` header so the cached entrypoint cannot produce a
- * cookie-dependent response. The Workers Caching key does not include cookies,
- * so anything derived from them could be served to the wrong visitor.
- */
+/** Strips cookies because Workers cache keys do not include them. */
 export function toAnonymousRequest(request: Request): Request {
 	const anonymousRequest = new Request(request);
 	anonymousRequest.headers.delete('Cookie');
 	return anonymousRequest;
 }
+
+/**
+ * Matches collection documents. `.data` is excluded because only
+ * document responses have been verified for caching.
+ */
+const COLLECTION_PATH_PATTERN = /^\/(?:ladies|mens)\/collections\/[^/.]+\/?$/;

--- a/apps/web/app/lib/anonymous-cache.unit.test.ts
+++ b/apps/web/app/lib/anonymous-cache.unit.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { isAnonymousCollectionRequest, toAnonymousRequest } from './anonymous-cache';
+
+const ORIGIN = 'https://www.glfonline.com.au';
+
+function createRequest(path: string, init?: RequestInit): Request {
+	return new Request(`${ORIGIN}${path}`, init);
+}
+
+describe('isAnonymousCollectionRequest', () => {
+	it('accepts an anonymous GET for a collection page', () => {
+		expect(isAnonymousCollectionRequest(createRequest('/ladies/collections/apparel'))).toBe(true);
+		expect(isAnonymousCollectionRequest(createRequest('/mens/collections/apparel'))).toBe(true);
+	});
+
+	it('accepts an anonymous HEAD for a collection page', () => {
+		expect(isAnonymousCollectionRequest(createRequest('/ladies/collections/apparel', { method: 'HEAD' }))).toBe(true);
+	});
+
+	it('accepts a trailing slash', () => {
+		expect(isAnonymousCollectionRequest(createRequest('/ladies/collections/apparel/'))).toBe(true);
+	});
+
+	it('accepts filter, sort and pagination query params', () => {
+		expect(
+			isAnonymousCollectionRequest(createRequest('/ladies/collections/apparel?sort=price-asc&productType=shirt')),
+		).toBe(true);
+		expect(isAnonymousCollectionRequest(createRequest('/ladies/collections/apparel?after=cursor123'))).toBe(true);
+	});
+
+	it('accepts requests carrying unrelated cookies', () => {
+		expect(
+			isAnonymousCollectionRequest(
+				createRequest('/ladies/collections/apparel', { headers: { Cookie: '_ga=GA1.1.1.1' } }),
+			),
+		).toBe(true);
+		expect(
+			isAnonymousCollectionRequest(
+				createRequest('/ladies/collections/apparel', {
+					headers: { Cookie: 'cookie_consent=accepted; _ga=GA1.1.1.1' },
+				}),
+			),
+		).toBe(true);
+	});
+
+	it('rejects requests carrying a session cookie', () => {
+		expect(
+			isAnonymousCollectionRequest(
+				createRequest('/ladies/collections/apparel', { headers: { Cookie: 'session=abc' } }),
+			),
+		).toBe(false);
+		expect(
+			isAnonymousCollectionRequest(
+				createRequest('/ladies/collections/apparel', { headers: { Cookie: '_ga=GA1.1.1.1; session=abc' } }),
+			),
+		).toBe(false);
+	});
+
+	it('rejects non-GET/HEAD methods', () => {
+		expect(isAnonymousCollectionRequest(createRequest('/ladies/collections/apparel', { method: 'POST' }))).toBe(false);
+	});
+
+	it('rejects single-fetch data URLs', () => {
+		expect(isAnonymousCollectionRequest(createRequest('/ladies/collections/apparel.data'))).toBe(false);
+	});
+
+	it('rejects paths that are not collection pages', () => {
+		expect(isAnonymousCollectionRequest(createRequest('/cart'))).toBe(false);
+		expect(isAnonymousCollectionRequest(createRequest('/ladies/products/foo'))).toBe(false);
+		expect(isAnonymousCollectionRequest(createRequest('/api/contact'))).toBe(false);
+		expect(isAnonymousCollectionRequest(createRequest('/'))).toBe(false);
+		expect(isAnonymousCollectionRequest(createRequest('/about'))).toBe(false);
+		expect(isAnonymousCollectionRequest(createRequest('/blog/x'))).toBe(false);
+		expect(isAnonymousCollectionRequest(createRequest('/ladies/collections/'))).toBe(false);
+	});
+});
+
+describe('toAnonymousRequest', () => {
+	it('strips the Cookie header', () => {
+		const request = createRequest('/ladies/collections/apparel', { headers: { Cookie: '_ga=GA1.1.1.1' } });
+		expect(toAnonymousRequest(request).headers.get('Cookie')).toBeNull();
+	});
+
+	it('preserves the method, URL and other headers', () => {
+		const request = createRequest('/ladies/collections/apparel?sort=price-asc', {
+			headers: { Accept: 'text/html', Cookie: '_ga=GA1.1.1.1', 'X-Forwarded-For': '203.0.113.1' },
+			method: 'HEAD',
+		});
+		const anonymousRequest = toAnonymousRequest(request);
+		expect(anonymousRequest.method).toBe('HEAD');
+		expect(anonymousRequest.url).toBe(`${ORIGIN}/ladies/collections/apparel?sort=price-asc`);
+		expect(anonymousRequest.headers.get('Accept')).toBe('text/html');
+		expect(anonymousRequest.headers.get('X-Forwarded-For')).toBe('203.0.113.1');
+	});
+
+	it('leaves the original request untouched', () => {
+		const request = createRequest('/ladies/collections/apparel', { headers: { Cookie: '_ga=GA1.1.1.1' } });
+		toAnonymousRequest(request);
+		expect(request.headers.get('Cookie')).toBe('_ga=GA1.1.1.1');
+	});
+});

--- a/apps/web/app/lib/cache.ts
+++ b/apps/web/app/lib/cache.ts
@@ -61,6 +61,13 @@ function generateCacheControlHeader(cacheOptions: CachingStrategy): string {
 	return cacheControl.join(', ');
 }
 
+/**
+ * Cloudflare's edge-only cache directive. It takes precedence over
+ * `CDN-Cache-Control` and `Cache-Control`, and Cloudflare consumes it — the
+ * response that reaches the client no longer carries it.
+ */
+export const CDN_CACHE_CONTROL_HEADER = 'Cloudflare-CDN-Cache-Control';
+
 export function routeHeaders({ loaderHeaders }: { loaderHeaders: Headers }) {
 	// Keep the same cache-control headers when loading the page directly
 	// versus when transitioning to the page from other areas in the app
@@ -94,12 +101,20 @@ function CacheShort(overrideOptions?: CachingStrategy): AllCacheOptions {
 	};
 }
 
-function CacheCollection(overrideOptions?: CachingStrategy): AllCacheOptions {
+/**
+ * The edge lifetime of a collection page: five minutes fresh, then up to an hour
+ * served stale while Cloudflare refreshes it in the background.
+ *
+ * `max-age` rather than `s-maxage` because `s-maxage` implies `proxy-revalidate`,
+ * which disables `stale-while-revalidate` (RFC 9111 §4.2.4). Sent as
+ * `Cloudflare-CDN-Cache-Control` so the edge lifetime is independent of what
+ * browsers cache.
+ */
+function CacheCollectionEdge(overrideOptions?: CachingStrategy): AllCacheOptions {
 	guardExpirableModeType(overrideOptions);
 	return {
 		mode: PUBLIC,
-		maxAge: 1,
-		sMaxAge: 300, // 5 minutes
+		maxAge: 300, // 5 minutes
 		staleWhileRevalidate: 3600, // 1 hour
 		...overrideOptions,
 	};
@@ -126,7 +141,7 @@ function CacheLong(overrideOptions?: CachingStrategy): AllCacheOptions {
 }
 
 export const CACHE_SHORT = generateCacheControlHeader(CacheShort());
-export const CACHE_COLLECTION = generateCacheControlHeader(CacheCollection());
+export const CACHE_COLLECTION_EDGE = generateCacheControlHeader(CacheCollectionEdge());
 export const CACHE_MEDIUM = generateCacheControlHeader(CacheMedium());
 export const CACHE_LONG = generateCacheControlHeader(CacheLong());
 export const CACHE_NONE = generateCacheControlHeader(CacheNone());

--- a/apps/web/app/lib/cache.ts
+++ b/apps/web/app/lib/cache.ts
@@ -61,11 +61,7 @@ function generateCacheControlHeader(cacheOptions: CachingStrategy): string {
 	return cacheControl.join(', ');
 }
 
-/**
- * Cloudflare's edge-only cache directive. It takes precedence over
- * `CDN-Cache-Control` and `Cache-Control`, and Cloudflare consumes it — the
- * response that reaches the client no longer carries it.
- */
+/** Cloudflare's edge-only cache header. */
 export const CDN_CACHE_CONTROL_HEADER = 'Cloudflare-CDN-Cache-Control';
 
 export function routeHeaders({ loaderHeaders }: { loaderHeaders: Headers }) {
@@ -101,15 +97,7 @@ function CacheShort(overrideOptions?: CachingStrategy): AllCacheOptions {
 	};
 }
 
-/**
- * The edge lifetime of a collection page: five minutes fresh, then up to an hour
- * served stale while Cloudflare refreshes it in the background.
- *
- * `max-age` rather than `s-maxage` because `s-maxage` implies `proxy-revalidate`,
- * which disables `stale-while-revalidate` (RFC 9111 §4.2.4). Sent as
- * `Cloudflare-CDN-Cache-Control` so the edge lifetime is independent of what
- * browsers cache.
- */
+// `s-maxage` implies `proxy-revalidate`, preventing stale-while-revalidate (RFC 9111 §4.2.4).
 function CacheCollectionEdge(overrideOptions?: CachingStrategy): AllCacheOptions {
 	guardExpirableModeType(overrideOptions);
 	return {

--- a/apps/web/app/lib/cache.ts
+++ b/apps/web/app/lib/cache.ts
@@ -94,6 +94,17 @@ function CacheShort(overrideOptions?: CachingStrategy): AllCacheOptions {
 	};
 }
 
+function CacheCollection(overrideOptions?: CachingStrategy): AllCacheOptions {
+	guardExpirableModeType(overrideOptions);
+	return {
+		mode: PUBLIC,
+		maxAge: 1,
+		sMaxAge: 300, // 5 minutes
+		staleWhileRevalidate: 3600, // 1 hour
+		...overrideOptions,
+	};
+}
+
 function CacheMedium(overrideOptions?: CachingStrategy): AllCacheOptions {
 	guardExpirableModeType(overrideOptions);
 	return {
@@ -115,6 +126,7 @@ function CacheLong(overrideOptions?: CachingStrategy): AllCacheOptions {
 }
 
 export const CACHE_SHORT = generateCacheControlHeader(CacheShort());
+export const CACHE_COLLECTION = generateCacheControlHeader(CacheCollection());
 export const CACHE_MEDIUM = generateCacheControlHeader(CacheMedium());
 export const CACHE_LONG = generateCacheControlHeader(CacheLong());
 export const CACHE_NONE = generateCacheControlHeader(CacheNone());

--- a/apps/web/app/lib/cache.unit.test.ts
+++ b/apps/web/app/lib/cache.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { CACHE_COLLECTION_EDGE, CACHE_SHORT, routeHeaders } from './cache';
+
+describe('CACHE_COLLECTION_EDGE', () => {
+	it('is five minutes fresh with an hour of stale-while-revalidate', () => {
+		expect(CACHE_COLLECTION_EDGE).toBe('public, max-age=300, stale-while-revalidate=3600');
+	});
+
+	it.each(['s-maxage', 'must-revalidate', 'proxy-revalidate'])(
+		// Each of these directives silently disables `stale-while-revalidate`
+		// (RFC 9111 §4.2.4), which would turn every stale hit into a blocking
+		// revalidation at the edge.
+		'does not contain %s',
+		(directive) => {
+			expect(CACHE_COLLECTION_EDGE).not.toContain(directive);
+		},
+	);
+});
+
+describe('routeHeaders', () => {
+	it('forwards Cache-Control when present', () => {
+		const loaderHeaders = new Headers({ 'Cache-Control': CACHE_SHORT });
+		expect(routeHeaders({ loaderHeaders })).toEqual({ 'Cache-Control': CACHE_SHORT });
+	});
+
+	it('returns an empty object when Cache-Control is absent', () => {
+		expect(routeHeaders({ loaderHeaders: new Headers() })).toEqual({});
+	});
+});

--- a/apps/web/app/lib/cart-model.ts
+++ b/apps/web/app/lib/cart-model.ts
@@ -18,6 +18,9 @@ export type CartView =
 	| { type: 'error'; error: string }
 	| { type: 'success'; cart: Cart; linesDisplay: Array<LineDisplay> };
 
+/** The cart a visitor without a session sees — and no session is created to say so. */
+export const EMPTY_CART_VIEW: CartView = { type: 'empty' };
+
 export type CartModel = {
 	read(): Promise<CartView>;
 	add(variantId: string, quantity: number): Promise<void>;

--- a/apps/web/app/lib/cart-model.ts
+++ b/apps/web/app/lib/cart-model.ts
@@ -18,7 +18,7 @@ export type CartView =
 	| { type: 'error'; error: string }
 	| { type: 'success'; cart: Cart; linesDisplay: Array<LineDisplay> };
 
-/** The cart a visitor without a session sees — and no session is created to say so. */
+/** Empty cart state used without creating a session. */
 export const EMPTY_CART_VIEW: CartView = { type: 'empty' };
 
 export type CartModel = {

--- a/apps/web/app/lib/cart.ts
+++ b/apps/web/app/lib/cart.ts
@@ -1,4 +1,5 @@
 import { createCookieSessionStorage } from 'react-router';
+import { SESSION_COOKIE_NAME } from './session-cookie';
 
 export type CartItem = {
 	variantId: string;
@@ -18,7 +19,7 @@ if (!process.env.ENCRYPTION_KEY) {
 const sessionStorage = createCookieSessionStorage({
 	cookie: {
 		httpOnly: true,
-		name: 'session',
+		name: SESSION_COOKIE_NAME,
 		path: '/',
 		sameSite: 'lax',
 		secrets: [process.env.ENCRYPTION_KEY],

--- a/apps/web/app/lib/session-cookie.ts
+++ b/apps/web/app/lib/session-cookie.ts
@@ -1,23 +1,9 @@
-/**
- * The name of the cart session cookie, and a reader for it.
- *
- * This lives apart from `cart.ts` because two very different places need to
- * agree on the name: `cart.ts` sets the cookie, and the Worker gateway in
- * `workers/app.ts` reads it to decide whether a request is anonymous.
- *
- * It is deliberately side-effect free — importing it must not pull in
- * `cart.ts`'s module-load `ENCRYPTION_KEY` check, which would run the app's
- * session storage setup inside the gateway for no reason.
- */
+// Kept separate from `cart.ts` so the Worker does not initialise session storage.
 export const SESSION_COOKIE_NAME = 'session';
 
-/**
- * Matches the `session` cookie in any position within a `Cookie` header, with
- * or without surrounding whitespace, without matching cookies that merely end
- * or begin with the same letters (`not_session`, `sessionid`, `mysession`).
- */
-const SESSION_COOKIE_PATTERN = new RegExp(`(?:^|;)\\s*${SESSION_COOKIE_NAME}\\s*=`);
-
+/** Checks for the exact session cookie name in a `Cookie` header. */
 export function hasSessionCookie(cookieHeader: string | null): boolean {
 	return cookieHeader ? SESSION_COOKIE_PATTERN.test(cookieHeader) : false;
 }
+
+const SESSION_COOKIE_PATTERN = new RegExp(`(?:^|;)\\s*${SESSION_COOKIE_NAME}\\s*=`);

--- a/apps/web/app/lib/session-cookie.ts
+++ b/apps/web/app/lib/session-cookie.ts
@@ -1,0 +1,23 @@
+/**
+ * The name of the cart session cookie, and a reader for it.
+ *
+ * This lives apart from `cart.ts` because two very different places need to
+ * agree on the name: `cart.ts` sets the cookie, and the Worker gateway in
+ * `workers/app.ts` reads it to decide whether a request is anonymous.
+ *
+ * It is deliberately side-effect free — importing it must not pull in
+ * `cart.ts`'s module-load `ENCRYPTION_KEY` check, which would run the app's
+ * session storage setup inside the gateway for no reason.
+ */
+export const SESSION_COOKIE_NAME = 'session';
+
+/**
+ * Matches the `session` cookie in any position within a `Cookie` header, with
+ * or without surrounding whitespace, without matching cookies that merely end
+ * or begin with the same letters (`not_session`, `sessionid`, `mysession`).
+ */
+const SESSION_COOKIE_PATTERN = new RegExp(`(?:^|;)\\s*${SESSION_COOKIE_NAME}\\s*=`);
+
+export function hasSessionCookie(cookieHeader: string | null): boolean {
+	return cookieHeader ? SESSION_COOKIE_PATTERN.test(cookieHeader) : false;
+}

--- a/apps/web/app/lib/session-cookie.unit.test.ts
+++ b/apps/web/app/lib/session-cookie.unit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { hasSessionCookie, SESSION_COOKIE_NAME } from './session-cookie';
+
+describe('SESSION_COOKIE_NAME', () => {
+	it('is the name the cart session storage writes', () => {
+		expect(SESSION_COOKIE_NAME).toBe('session');
+	});
+});
+
+describe('hasSessionCookie', () => {
+	it('returns false when there is no Cookie header', () => {
+		expect(hasSessionCookie(null)).toBe(false);
+	});
+
+	it('returns false for an empty Cookie header', () => {
+		expect(hasSessionCookie('')).toBe(false);
+	});
+
+	it('returns true when the session cookie is the only cookie', () => {
+		expect(hasSessionCookie('session=abc')).toBe(true);
+	});
+
+	it('returns true when the session cookie follows another cookie', () => {
+		expect(hasSessionCookie('_ga=1; session=abc')).toBe(true);
+	});
+
+	it('returns true when the session cookie precedes another cookie', () => {
+		expect(hasSessionCookie('session=abc; _ga=1')).toBe(true);
+	});
+
+	it('tolerates leading and extra whitespace', () => {
+		expect(hasSessionCookie('   session=abc')).toBe(true);
+		expect(hasSessionCookie('_ga=1;    session=abc')).toBe(true);
+		expect(hasSessionCookie('_ga=1;session=abc')).toBe(true);
+	});
+
+	it('does not match cookies whose names merely contain "session"', () => {
+		expect(hasSessionCookie('not_session=abc')).toBe(false);
+		expect(hasSessionCookie('sessionid=abc')).toBe(false);
+		expect(hasSessionCookie('mysession=abc')).toBe(false);
+		expect(hasSessionCookie('_ga=1; not_session=abc; sessionid=def')).toBe(false);
+	});
+});

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -82,10 +82,7 @@ export const links: LinksFunction = () => {
 
 export async function loader({ context, request }: LoaderFunctionArgs) {
 	const storefront = context.get(storefrontContext);
-	// Visitors without a session have no cart to read, and must not be given one
-	// here: a `Set-Cookie` on an otherwise anonymous page would make the response
-	// uncacheable. Adding the first item to a cart still creates the session
-	// normally, in the product and cart route actions.
+	// Only load an existing session; `Set-Cookie` prevents anonymous caching.
 	const session = hasSessionCookie(request.headers.get('Cookie')) ? await getSession(request) : null;
 	const cart = session ? createCart({ session, storefront }) : null;
 

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -81,11 +81,11 @@ export const links: LinksFunction = () => {
 
 export async function loader({ context, request }: LoaderFunctionArgs) {
 	const storefront = context.get(storefrontContext);
-	const session = await getSession(request);
-	const cart = createCart({ session, storefront });
+	const session = request.headers.get('Cookie') ? await getSession(request) : undefined;
+	const cart = session ? createCart({ session, storefront }) : undefined;
 
 	const [view, { shop }, mainNavigation] = await Promise.all([
-		cart.read(),
+		cart ? cart.read() : Promise.resolve({ type: 'empty' } as const),
 		storefront.request(SHOP_QUERY),
 		getMainNavigation(),
 	]);
@@ -110,9 +110,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
 			shop,
 		},
 		{
-			headers: {
-				'Set-Cookie': await session.commitSession(),
-			},
+			headers: session ? { 'Set-Cookie': await session.commitSession() } : undefined,
 		},
 	);
 }

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -29,9 +29,10 @@ import { MainLayout } from './components/main-layout';
 import { NotFound } from './components/not-found';
 import fontCssUrl from './font.css?url';
 import { getSession } from './lib/cart';
-import { createCart } from './lib/cart-model';
+import { createCart, EMPTY_CART_VIEW } from './lib/cart-model';
 import { getMainNavigation } from './lib/get-main-navigation';
 import * as gtag from './lib/gtag';
+import { hasSessionCookie } from './lib/session-cookie';
 import { getSeoMeta, seoConfig } from './seo';
 import tailwindCssUrl from './tailwind.css?url';
 
@@ -81,11 +82,15 @@ export const links: LinksFunction = () => {
 
 export async function loader({ context, request }: LoaderFunctionArgs) {
 	const storefront = context.get(storefrontContext);
-	const session = request.headers.get('Cookie') ? await getSession(request) : undefined;
-	const cart = session ? createCart({ session, storefront }) : undefined;
+	// Visitors without a session have no cart to read, and must not be given one
+	// here: a `Set-Cookie` on an otherwise anonymous page would make the response
+	// uncacheable. Adding the first item to a cart still creates the session
+	// normally, in the product and cart route actions.
+	const session = hasSessionCookie(request.headers.get('Cookie')) ? await getSession(request) : null;
+	const cart = session ? createCart({ session, storefront }) : null;
 
 	const [view, { shop }, mainNavigation] = await Promise.all([
-		cart ? cart.read() : Promise.resolve({ type: 'empty' } as const),
+		cart ? cart.read() : EMPTY_CART_VIEW,
 		storefront.request(SHOP_QUERY),
 		getMainNavigation(),
 	]);
@@ -102,6 +107,8 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
 		}
 	}
 
+	const responseInit = session ? { headers: { 'Set-Cookie': await session.commitSession() } } : undefined;
+
 	return data(
 		{
 			cartCount,
@@ -109,9 +116,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
 			mainNavigation,
 			shop,
 		},
-		{
-			headers: session ? { 'Set-Cookie': await session.commitSession() } : undefined,
-		},
+		responseInit,
 	);
 }
 

--- a/apps/web/app/routes/$theme.collections.$collection.tsx
+++ b/apps/web/app/routes/$theme.collections.$collection.tsx
@@ -8,7 +8,7 @@ import { Filters, MobileFilters } from '../components/collection-filters';
 import { ButtonLink } from '../components/design-system/button-link';
 import { DiagonalBanner } from '../components/diagonal-banner';
 import { Hero } from '../components/hero';
-import { CACHE_SHORT, routeHeaders } from '../lib/cache';
+import { CACHE_COLLECTION, routeHeaders } from '../lib/cache';
 import { badRequest, notFound, serverError } from '../lib/errors.server';
 import { formatMoney } from '../lib/format-money';
 import { getProductsFromCollectionByTag } from '../lib/get-collection-products';
@@ -157,7 +157,7 @@ export async function loader({ context, params, url }: LoaderFunctionArgs) {
 		},
 		{
 			headers: {
-				'Cache-Control': CACHE_SHORT,
+				'Cache-Control': CACHE_COLLECTION,
 			},
 		},
 	);

--- a/apps/web/app/routes/$theme.collections.$collection.tsx
+++ b/apps/web/app/routes/$theme.collections.$collection.tsx
@@ -8,7 +8,7 @@ import { Filters, MobileFilters } from '../components/collection-filters';
 import { ButtonLink } from '../components/design-system/button-link';
 import { DiagonalBanner } from '../components/diagonal-banner';
 import { Hero } from '../components/hero';
-import { CACHE_COLLECTION, routeHeaders } from '../lib/cache';
+import { CACHE_SHORT, routeHeaders } from '../lib/cache';
 import { badRequest, notFound, serverError } from '../lib/errors.server';
 import { formatMoney } from '../lib/format-money';
 import { getProductsFromCollectionByTag } from '../lib/get-collection-products';
@@ -156,8 +156,11 @@ export async function loader({ context, params, url }: LoaderFunctionArgs) {
 			title: collection.title,
 		},
 		{
+			// The edge lifetime for anonymous requests is set by the `CachedApp`
+			// entrypoint in `workers/app.ts`, so this header is only what
+			// browsers see.
 			headers: {
-				'Cache-Control': CACHE_COLLECTION,
+				'Cache-Control': CACHE_SHORT,
 			},
 		},
 	);

--- a/apps/web/workers/app.ts
+++ b/apps/web/workers/app.ts
@@ -1,8 +1,16 @@
 import * as Sentry from '@sentry/cloudflare';
+import { WorkerEntrypoint } from 'cloudflare:workers';
 import { createRequestHandler } from 'react-router';
+import { isAnonymousCollectionRequest, toAnonymousRequest } from '../app/lib/anonymous-cache';
+import { CACHE_COLLECTION_EDGE, CDN_CACHE_CONTROL_HEADER } from '../app/lib/cache';
 
 type Env = {
 	SENTRY_DSN?: string;
+};
+
+/** The slice of `ExecutionContext` the gateway uses. */
+type GatewayContext = {
+	exports: { CachedApp: { fetch(request: Request): Promise<Response> } };
 };
 
 const requestHandler = createRequestHandler(() => import('virtual:react-router/server-build'), import.meta.env.MODE);
@@ -12,8 +20,8 @@ const requestHandler = createRequestHandler(() => import('virtual:react-router/s
  * which is where Cloudflare gives us an isolate to hang the client off. It
  * replaces the `instrumentation.server.mjs` file the Node build used to preload.
  */
-export default Sentry.withSentry(
-	(env: Env) => ({
+function sentryOptions(env: Env): Sentry.CloudflareOptions {
+	return {
 		dsn:
 			env.SENTRY_DSN ||
 			'https://a2413a79501942ae9580c3a12c4addb2@o4504862915297280.ingest.us.sentry.io/4504862916476928',
@@ -38,12 +46,56 @@ export default Sentry.withSentry(
 
 			return event;
 		},
-	}),
-	{
-		// No load context: React Router 8 takes a `RouterContextProvider`, not v7's
-		// `{ cloudflare }` object, and nothing here reads bindings from a loader.
-		fetch(request: Request) {
-			return requestHandler(request);
-		},
+	};
+}
+
+/**
+ * The cached entrypoint. Workers Caching sits in front of it (see `exports` in
+ * `wrangler.jsonc`), so a repeat request for the same URL can be answered before
+ * any of this runs.
+ *
+ * Sentry is initialised here as well as on the gateway because Cloudflare
+ * invokes this entrypoint on its own to fill and revalidate the cache, where the
+ * gateway's Sentry context does not apply.
+ *
+ * The edge cache directive is set here rather than on the route: only requests
+ * the gateway judged anonymous and cacheable ever reach this entrypoint, so this
+ * is the only place the directive is guaranteed to be correct. A route-level
+ * header would also land on single-fetch `.data` responses and on
+ * session-bearing requests that bypass the cache.
+ */
+export const CachedApp = Sentry.withSentry(
+	sentryOptions,
+	class extends WorkerEntrypoint<Env> {
+		async fetch(request: Request): Promise<Response> {
+			const response = await requestHandler(request);
+			// Only successful pages earn an edge lifetime. Errors must not be
+			// cached for five minutes, and a 404 is better left to Cloudflare's
+			// much shorter heuristic freshness.
+			if (response.ok) {
+				response.headers.set(CDN_CACHE_CONTROL_HEADER, CACHE_COLLECTION_EDGE);
+			}
+			return response;
+		}
 	},
 );
+
+/**
+ * The gateway. Caching is off for the default export, so this runs on every
+ * request — which is exactly why the cache decision lives here and not in
+ * `root.tsx`: Workers Caching can answer from the cache before React Router runs
+ * at all, so anything inside the app is too late to decide what may be cached.
+ *
+ * It must therefore stay small and uncached: route anonymous collection requests
+ * to `CachedApp`, run everything else inline exactly as before.
+ */
+export default Sentry.withSentry(sentryOptions, {
+	// No load context: React Router 8 takes a `RouterContextProvider`, not v7's
+	// `{ cloudflare }` object, and nothing here reads bindings from a loader.
+	fetch(request: Request, _env: Env, ctx: GatewayContext) {
+		if (isAnonymousCollectionRequest(request)) {
+			return ctx.exports.CachedApp.fetch(toAnonymousRequest(request));
+		}
+		return requestHandler(request);
+	},
+});

--- a/apps/web/workers/app.ts
+++ b/apps/web/workers/app.ts
@@ -15,63 +15,13 @@ type GatewayContext = {
 
 const requestHandler = createRequestHandler(() => import('virtual:react-router/server-build'), import.meta.env.MODE);
 
-/**
- * `withSentry` initialises the Sentry client inside the Worker's fetch handler,
- * which is where Cloudflare gives us an isolate to hang the client off. It
- * replaces the `instrumentation.server.mjs` file the Node build used to preload.
- */
-function sentryOptions(env: Env): Sentry.CloudflareOptions {
-	return {
-		dsn:
-			env.SENTRY_DSN ||
-			'https://a2413a79501942ae9580c3a12c4addb2@o4504862915297280.ingest.us.sentry.io/4504862916476928',
-		// Only report from production builds, matching the client-side gate in `entry.client.tsx`.
-		enabled: import.meta.env.PROD,
-		environment: import.meta.env.MODE,
-		// No `denyUrls` here: it filtered browser asset noise (/build/, /img/,
-		// /fonts/ …) and has no server-side purpose — Cloudflare's assets binding
-		// serves static files without ever invoking this Worker. Worse, the
-		// `/build/` pattern matches Worker stack frames and was observed silently
-		// dropping a real server error, which is the failure mode this migration
-		// exists to fix.
-		tracesSampler() {
-			return import.meta.env.MODE === 'production' ? 1 : 0;
-		},
-		beforeSendTransaction(event) {
-			// ignore all healthcheck related transactions
-			//  note that name of header here is case-sensitive
-			if (event.request?.headers?.['x-healthcheck'] === 'true') {
-				return null;
-			}
-
-			return event;
-		},
-	};
-}
-
-/**
- * The cached entrypoint. Workers Caching sits in front of it (see `exports` in
- * `wrangler.jsonc`), so a repeat request for the same URL can be answered before
- * any of this runs.
- *
- * Sentry is initialised here as well as on the gateway because Cloudflare
- * invokes this entrypoint on its own to fill and revalidate the cache, where the
- * gateway's Sentry context does not apply.
- *
- * The edge cache directive is set here rather than on the route: only requests
- * the gateway judged anonymous and cacheable ever reach this entrypoint, so this
- * is the only place the directive is guaranteed to be correct. A route-level
- * header would also land on single-fetch `.data` responses and on
- * session-bearing requests that bypass the cache.
- */
+/** Cached entrypoint for anonymous collection documents. */
 export const CachedApp = Sentry.withSentry(
 	sentryOptions,
 	class extends WorkerEntrypoint<Env> {
 		async fetch(request: Request): Promise<Response> {
 			const response = await requestHandler(request);
-			// Only successful pages earn an edge lifetime. Errors must not be
-			// cached for five minutes, and a 404 is better left to Cloudflare's
-			// much shorter heuristic freshness.
+			// Only successful document responses get the five-minute edge lifetime.
 			if (response.ok) {
 				response.headers.set(CDN_CACHE_CONTROL_HEADER, CACHE_COLLECTION_EDGE);
 			}
@@ -80,22 +30,38 @@ export const CachedApp = Sentry.withSentry(
 	},
 );
 
-/**
- * The gateway. Caching is off for the default export, so this runs on every
- * request — which is exactly why the cache decision lives here and not in
- * `root.tsx`: Workers Caching can answer from the cache before React Router runs
- * at all, so anything inside the app is too late to decide what may be cached.
- *
- * It must therefore stay small and uncached: route anonymous collection requests
- * to `CachedApp`, run everything else inline exactly as before.
- */
 export default Sentry.withSentry(sentryOptions, {
 	// No load context: React Router 8 takes a `RouterContextProvider`, not v7's
 	// `{ cloudflare }` object, and nothing here reads bindings from a loader.
 	fetch(request: Request, _env: Env, ctx: GatewayContext) {
+		// Workers Caching runs before React Router, so select cacheable requests here.
 		if (isAnonymousCollectionRequest(request)) {
 			return ctx.exports.CachedApp.fetch(toAnonymousRequest(request));
 		}
 		return requestHandler(request);
 	},
 });
+
+/** Initialises Sentry inside each entrypoint's Worker isolate. */
+function sentryOptions(env: Env): Sentry.CloudflareOptions {
+	return {
+		dsn:
+			env.SENTRY_DSN ||
+			'https://a2413a79501942ae9580c3a12c4addb2@o4504862915297280.ingest.us.sentry.io/4504862916476928',
+		// Only report from production builds, matching the client-side gate in `entry.client.tsx`.
+		enabled: import.meta.env.PROD,
+		environment: import.meta.env.MODE,
+		// `denyUrls` can match Worker stack frames and hide server errors.
+		tracesSampler() {
+			return import.meta.env.MODE === 'production' ? 1 : 0;
+		},
+		beforeSendTransaction(event) {
+			// Header names are case-sensitive here.
+			if (event.request?.headers?.['x-healthcheck'] === 'true') {
+				return null;
+			}
+
+			return event;
+		},
+	};
+}

--- a/apps/web/workers/cloudflare.d.ts
+++ b/apps/web/workers/cloudflare.d.ts
@@ -1,11 +1,4 @@
-/**
- * Minimal ambient types for the Cloudflare runtime APIs `app.ts` uses.
- *
- * `wrangler types` generates the full runtime types, but they redeclare
- * `Request`, `Response` and friends as globals, which conflicts with the `DOM`
- * lib the React app is typechecked against. Only the surface this Worker
- * touches is declared here.
- */
+/** Minimal Worker types that avoid conflicts between Wrangler globals and DOM types. */
 declare module 'cloudflare:workers' {
 	export abstract class WorkerEntrypoint<Env = unknown> {
 		protected readonly env: Env;

--- a/apps/web/workers/cloudflare.d.ts
+++ b/apps/web/workers/cloudflare.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Minimal ambient types for the Cloudflare runtime APIs `app.ts` uses.
+ *
+ * `wrangler types` generates the full runtime types, but they redeclare
+ * `Request`, `Response` and friends as globals, which conflicts with the `DOM`
+ * lib the React app is typechecked against. Only the surface this Worker
+ * touches is declared here.
+ */
+declare module 'cloudflare:workers' {
+	export abstract class WorkerEntrypoint<Env = unknown> {
+		protected readonly env: Env;
+	}
+}

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -6,6 +6,9 @@
 	// 2025-04-01 onwards, Cloudflare populates `process.env` from bindings.
 	"compatibility_date": "2026-08-01",
 	"compatibility_flags": ["nodejs_compat"],
+	"cache": {
+		"enabled": true
+	},
 	"assets": {
 		"directory": "./build/client"
 	},

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -6,10 +6,7 @@
 	// 2025-04-01 onwards, Cloudflare populates `process.env` from bindings.
 	"compatibility_date": "2026-08-01",
 	"compatibility_flags": ["nodejs_compat"],
-	// Workers Caching sits in front of `CachedApp` only — the entrypoint the
-	// gateway in `workers/app.ts` routes anonymous collection page requests to.
-	// The default export (the gateway) and every other response stay uncached,
-	// so nothing else can be cached, including by RFC 9111 heuristic freshness.
+	// Cache only `CachedApp`. The default gateway and other responses stay uncached.
 	"exports": {
 		"CachedApp": { "type": "worker", "cache": { "enabled": true } }
 	},

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -6,8 +6,12 @@
 	// 2025-04-01 onwards, Cloudflare populates `process.env` from bindings.
 	"compatibility_date": "2026-08-01",
 	"compatibility_flags": ["nodejs_compat"],
-	"cache": {
-		"enabled": true
+	// Workers Caching sits in front of `CachedApp` only — the entrypoint the
+	// gateway in `workers/app.ts` routes anonymous collection page requests to.
+	// The default export (the gateway) and every other response stay uncached,
+	// so nothing else can be cached, including by RFC 9111 heuristic freshness.
+	"exports": {
+		"CachedApp": { "type": "worker", "cache": { "enabled": true } }
 	},
 	"assets": {
 		"directory": "./build/client"

--- a/packages/playwright/e2e/anonymous-collection-cache.spec.ts
+++ b/packages/playwright/e2e/anonymous-collection-cache.spec.ts
@@ -1,0 +1,101 @@
+import { randomUUID } from 'node:crypto';
+import type { APIRequestContext } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+import invariant from 'tiny-invariant';
+
+const COLLECTION_PATH = '/ladies/collections/apparel';
+const PRODUCT_PATH = '/ladies/products/nivo-belt-idna-white';
+const CART_PATH = '/cart';
+
+const SKIP_REASON = 'Workers Caching is not emulated locally — run against a deployed preview (BASE_URL).';
+
+/**
+ * The Workers Caching key includes the query string, so a unique param
+ * guarantees the first request for a URL is a miss rather than a hit left behind
+ * by an earlier test run or a real visitor.
+ */
+function uniqueUrl(baseURL: string, path: string): string {
+	return `${baseURL}${path}?cache-probe=${randomUUID()}`;
+}
+
+async function getCacheStatus(
+	request: APIRequestContext,
+	url: string,
+	headers?: Record<string, string>,
+): Promise<string | undefined> {
+	const response = await request.get(url, { headers });
+	expect(response.status()).toBe(200);
+	return response.headers()['cf-cache-status'];
+}
+
+/** Requests a URL until Cloudflare reports it as cached. */
+async function primeCache(request: APIRequestContext, url: string): Promise<void> {
+	// Filling the cache is not instant, so the hit is polled for rather than
+	// asserted on the second request.
+	await expect.poll(() => getCacheStatus(request, url)).toBe('HIT');
+}
+
+test.describe('Anonymous collection page cache status', () => {
+	/**
+	 * Local `wrangler dev`/miniflare does not emulate Workers Caching: the
+	 * entrypoint runs on every request and no `Cf-Cache-Status` header comes back.
+	 * These assertions only mean anything against a deployed preview, so they are
+	 * skipped when the probe shows no cache in front of the Worker.
+	 */
+	test.beforeEach(async ({ baseURL, request }) => {
+		invariant(baseURL, 'Base URL must be defined');
+		const status = await getCacheStatus(request, uniqueUrl(baseURL, COLLECTION_PATH));
+		test.skip(status === undefined, SKIP_REASON);
+	});
+
+	test('a repeat anonymous request is served from the cache', async ({ baseURL, request }) => {
+		invariant(baseURL, 'Base URL must be defined');
+		const url = uniqueUrl(baseURL, COLLECTION_PATH);
+
+		expect(await getCacheStatus(request, url)).toBe('MISS');
+		await primeCache(request, url);
+	});
+
+	test('a request carrying a session cookie is not served the anonymous cached response', async ({
+		baseURL,
+		request,
+	}) => {
+		invariant(baseURL, 'Base URL must be defined');
+		const url = uniqueUrl(baseURL, COLLECTION_PATH);
+		await primeCache(request, url);
+
+		expect(await getCacheStatus(request, url, { Cookie: 'session=e2e-not-a-real-session' })).not.toBe('HIT');
+	});
+
+	test('a request carrying an unrelated cookie is still served from the cache', async ({ baseURL, request }) => {
+		invariant(baseURL, 'Base URL must be defined');
+		const url = uniqueUrl(baseURL, COLLECTION_PATH);
+		await primeCache(request, url);
+
+		expect(await getCacheStatus(request, url, { Cookie: '_ga=GA1.1.1.1' })).toBe('HIT');
+	});
+
+	test('the cart and product pages are never served from the cache', async ({ baseURL, request }) => {
+		invariant(baseURL, 'Base URL must be defined');
+
+		for (const path of [CART_PATH, PRODUCT_PATH]) {
+			const url = uniqueUrl(baseURL, path);
+			expect(await getCacheStatus(request, url)).not.toBe('HIT');
+			expect(await getCacheStatus(request, url)).not.toBe('HIT');
+		}
+	});
+});
+
+/**
+ * No skip guard here: a `Set-Cookie` would make the response uncacheable
+ * everywhere, and that is worth catching locally too.
+ */
+test.describe('Anonymous collection page cookies', () => {
+	test('an anonymous collection page request sets no cookie', async ({ baseURL, request }) => {
+		invariant(baseURL, 'Base URL must be defined');
+
+		const response = await request.get(uniqueUrl(baseURL, COLLECTION_PATH));
+		expect(response.status()).toBe(200);
+		expect(response.headers()['set-cookie']).toBeUndefined();
+	});
+});

--- a/packages/playwright/e2e/anonymous-collection-cache.spec.ts
+++ b/packages/playwright/e2e/anonymous-collection-cache.spec.ts
@@ -7,15 +7,11 @@ const COLLECTION_PATH = '/ladies/collections/apparel';
 const PRODUCT_PATH = '/ladies/products/nivo-belt-idna-white';
 const CART_PATH = '/cart';
 
-const SKIP_REASON = 'Workers Caching is not emulated locally — run against a deployed preview (BASE_URL).';
+const SKIP_REASON = 'Workers Caching is not emulated locally. Run against a deployed preview (BASE_URL).';
 
-/**
- * The Workers Caching key includes the query string, so a unique param
- * guarantees the first request for a URL is a miss rather than a hit left behind
- * by an earlier test run or a real visitor.
- */
+/** Uses a unique, unknown sort value that falls back to the collection default. */
 function uniqueUrl(baseURL: string, path: string): string {
-	return `${baseURL}${path}?cache-probe=${randomUUID()}`;
+	return `${baseURL}${path}?sort=cache-probe-${randomUUID()}`;
 }
 
 async function getCacheStatus(
@@ -28,20 +24,13 @@ async function getCacheStatus(
 	return response.headers()['cf-cache-status'];
 }
 
-/** Requests a URL until Cloudflare reports it as cached. */
 async function primeCache(request: APIRequestContext, url: string): Promise<void> {
-	// Filling the cache is not instant, so the hit is polled for rather than
-	// asserted on the second request.
+	// Cache fills are asynchronous, so poll for the hit.
 	await expect.poll(() => getCacheStatus(request, url)).toBe('HIT');
 }
 
 test.describe('Anonymous collection page cache status', () => {
-	/**
-	 * Local `wrangler dev`/miniflare does not emulate Workers Caching: the
-	 * entrypoint runs on every request and no `Cf-Cache-Status` header comes back.
-	 * These assertions only mean anything against a deployed preview, so they are
-	 * skipped when the probe shows no cache in front of the Worker.
-	 */
+	// Skip locally because miniflare does not emulate Workers Caching.
 	test.beforeEach(async ({ baseURL, request }) => {
 		invariant(baseURL, 'Base URL must be defined');
 		const status = await getCacheStatus(request, uniqueUrl(baseURL, COLLECTION_PATH));
@@ -86,10 +75,7 @@ test.describe('Anonymous collection page cache status', () => {
 	});
 });
 
-/**
- * No skip guard here: a `Set-Cookie` would make the response uncacheable
- * everywhere, and that is worth catching locally too.
- */
+// `Set-Cookie` is testable locally and would make the response uncacheable.
 test.describe('Anonymous collection page cookies', () => {
 	test('an anonymous collection page request sets no cookie', async ({ baseURL, request }) => {
 		invariant(baseURL, 'Base URL must be defined');

--- a/packages/playwright/e2e/search-checkout-flow.spec.ts
+++ b/packages/playwright/e2e/search-checkout-flow.spec.ts
@@ -31,8 +31,7 @@ test.describe('Search and checkout flow', () => {
 	});
 
 	test('Add to cart 3 times shows 1 line with quantity 3 on cart page', async ({ context, page }) => {
-		// Browsing without a cart must not create a session: the `Set-Cookie` would
-		// make otherwise anonymous pages uncacheable at the edge.
+		// Browsing must not set a session cookie and disable anonymous caching.
 		expect(await getSessionCookie(context)).toBeUndefined();
 
 		await page.getByRole('button', { name: 'Search' }).first().click();
@@ -44,7 +43,7 @@ test.describe('Search and checkout flow', () => {
 		await addToCart(page);
 		await addToCart(page);
 
-		// Adding the first item still creates the session, in the route action.
+		// Adding an item creates the session in the route action.
 		expect(await getSessionCookie(context)).toBeDefined();
 
 		await page.getByRole('link', { name: CART_LINK_REGEX }).click();

--- a/packages/playwright/e2e/search-checkout-flow.spec.ts
+++ b/packages/playwright/e2e/search-checkout-flow.spec.ts
@@ -1,10 +1,15 @@
-import type { Page } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
 import invariant from 'tiny-invariant';
 
 const CHECKOUT_URL_REGEX = /^https:\/\/golfladiesfirst\.myshopify\.com\/checkouts\//;
 const CART_LINK_REGEX = /items in cart, view bag/;
 const ADD_TO_CART_BUTTON_REGEX = /add to cart|adding/i;
+
+async function getSessionCookie(context: BrowserContext) {
+	const cookies = await context.cookies();
+	return cookies.find((cookie) => cookie.name === 'session');
+}
 
 async function addToCart(page: Page) {
 	await page.getByRole('button', { name: ADD_TO_CART_BUTTON_REGEX }).click();
@@ -25,7 +30,11 @@ test.describe('Search and checkout flow', () => {
 		await page.goto(baseURL);
 	});
 
-	test('Add to cart 3 times shows 1 line with quantity 3 on cart page', async ({ page }) => {
+	test('Add to cart 3 times shows 1 line with quantity 3 on cart page', async ({ context, page }) => {
+		// Browsing without a cart must not create a session: the `Set-Cookie` would
+		// make otherwise anonymous pages uncacheable at the edge.
+		expect(await getSessionCookie(context)).toBeUndefined();
+
 		await page.getByRole('button', { name: 'Search' }).first().click();
 		await expect(page.getByTestId('search-input')).toBeVisible();
 		await page.getByTestId('search-input').fill('select height');
@@ -34,6 +43,9 @@ test.describe('Search and checkout flow', () => {
 		await addToCart(page);
 		await addToCart(page);
 		await addToCart(page);
+
+		// Adding the first item still creates the session, in the route action.
+		expect(await getSessionCookie(context)).toBeDefined();
 
 		await page.getByRole('link', { name: CART_LINK_REGEX }).click();
 		await expect(page.getByTestId('quantity-display').first()).toBeVisible();

--- a/packages/playwright/playwright.config.ts
+++ b/packages/playwright/playwright.config.ts
@@ -115,6 +115,8 @@ export default defineConfig({
 			command: 'pnpm -w dev:web',
 			reuseExistingServer: !process.env.CI,
 			url: baseURL,
+			/** Default (60s) isn't enough to boot the dev server on a cold CI runner; give it more headroom. */
+			timeout: 180_000,
 		};
 	})(),
 


### PR DESCRIPTION
## Why

Repeated collection-page requests were exhausting the compute allowance on the previous deployment. Collection pages are expensive (a Shopify collection query plus filter options) and identical for every anonymous visitor, so the fix is to stop running the Worker for them at all.

[Workers Caching](https://developers.cloudflare.com/workers/cache/) does exactly that: Cloudflare checks its cache *before* invoking the Worker, so a repeat request never reaches our code. The Cache API would not help — it only runs once the Worker is already executing, which is the cost being avoided.

## Why there is a gateway

Because the cache can answer before the Worker runs, the decision about what may be served from the anonymous cache cannot live inside React Router. By the time a loader runs, the cache has already decided. The [cache key](https://developers.cloudflare.com/workers/cache/cache-keys/) is built from the entrypoint, path and query string and **does not include cookies** — the docs are explicit that requests differing only in `Cookie` "return the same cached response". So a response-time check in `root.tsx` could never have stopped a session-bearing request being handed an anonymous cached page.

This uses Cloudflare's [documented gateway pattern](https://developers.cloudflare.com/workers/cache/examples/): a small, deliberately uncached default entrypoint that runs on every request and decides where to send it.

```
request
  ↓
gateway (default export, caching off)
  ↓
anonymous collection GET/HEAD?
  ├─ yes → CachedApp entrypoint (caching on)
  └─ no  → React Router, inline, exactly as before
```

`wrangler.jsonc` enables caching for `CachedApp` only:

```jsonc
"exports": {
	"CachedApp": { "type": "worker", "cache": { "enabled": true } }
}
```

The earlier revision of this PR set Worker-wide `cache.enabled: true`. That is dropped deliberately: it would have made every response cacheable, including RFC 9111 heuristic caching of responses carrying no explicit cache headers.

## Exactly which requests are cached

Cached:

- `GET`/`HEAD` for `/ladies/collections/<handle>` and `/mens/collections/<handle>`, with or without filter, sort and pagination params (the query string is part of the cache key, so each variant is cached separately).

Never cached — these run the app inline through the gateway, exactly as before:

- any request carrying the app's `session` cookie
- all form actions and any non-`GET`/`HEAD` method
- `/cart`, product pages, `/api/*`, and every other route
- React Router single-fetch `…/collections/<handle>.data` URLs. Excluded on purpose: the `headers` export's behaviour for single-fetch responses has not been verified, and a response without an explicit cache header would fall into heuristic caching. Client-side navigation therefore still runs the Worker; crawler and cold-load traffic — the actual source of the compute problem — does not.

## How session-bearing requests bypass the cache

The gateway matches the app's real `session` cookie, the one `createCookieSessionStorage` sets in `app/lib/cart.ts`. The earlier revision treated *any* `Cookie` header as a session, so an analytics or consent cookie was enough to make an otherwise anonymous request uncacheable.

Two further safeguards:

- The gateway strips `Cookie` before forwarding to `CachedApp`, so a cached response cannot depend on any cookie.
- `root.tsx` no longer creates a cart session for visitors that do not already have one, so anonymous pages no longer emit a pointless `Set-Cookie` — which would make them uncacheable anyway. Adding the first item to a cart still creates the session in the product and cart route actions; cart behaviour is unchanged once a session exists.

## Fresh and stale durations

```
Cache-Control:                public, max-age=1, stale-while-revalidate=9
Cloudflare-CDN-Cache-Control: public, max-age=300, stale-while-revalidate=3600
```

Browsers keep exactly the policy collection pages already had. The edge gets its own: **5 minutes fresh, then up to 1 hour served stale** while Cloudflare refreshes in the background. `Cloudflare-CDN-Cache-Control` outranks `Cache-Control` at Cloudflare and is stripped before the response reaches the browser, so the two lifetimes are independent.

The previous `s-maxage=300, stale-while-revalidate=3600` did not do what its comment claimed. Cloudflare documents that `s-maxage` — like `must-revalidate` and `proxy-revalidate` — **disables** `stale-while-revalidate`, per [RFC 9111 §4.2.4](https://www.rfc-editor.org/rfc/rfc9111#section-4.2.4), because it implies `proxy-revalidate` and shared caches must not serve stale content. That configuration would have blocked on a foreground revalidation every 5 minutes instead of serving stale for an hour.

The edge directive is set by the `CachedApp` entrypoint rather than by the route, and only when `response.ok`. Only requests the gateway already judged anonymous reach that entrypoint, so it is the one place the directive is guaranteed to be correct — a route-level header also landed on `.data` responses and on session-bearing requests. The `response.ok` guard keeps errors out of the cache: a 500 must not be advertised as cacheable for five minutes.

## How this was verified

Local `wrangler dev`/miniflare **does not emulate Workers Caching** — probed with a scratch Worker: no `Cf-Cache-Status`, and the cached entrypoint ran on every request. Miniflare's cache plugin only implements the Cache API. So the cache assertions were run by hand against the deployed previews for `c3ae6d9` and `0734fd6`.

| Request | Result |
|---|---|
| First anonymous collection request | `cf-cache-status: MISS` |
| Repeat of the same URL | `cf-cache-status: HIT` |
| Same URL + `Cookie: session=…` | no `cf-cache-status` at all — never reached the cached entrypoint, and set its own session cookie |
| Same URL + `Cookie: _ga=…; cookieconsent_status=allow` | `cf-cache-status: HIT` — unrelated cookies do not disable caching |
| `/cart` (twice) | never cached, `cache-control: no-store` |
| Product page, home page, `…/apparel.data` (twice each) | never cached |
| Nonexistent collection | `cf-cache-status: BYPASS` — errors are not cached |
| Anonymous collection response | no `Set-Cookie`; `Cloudflare-CDN-Cache-Control` stripped by Cloudflare as documented |

Automated coverage:

- `app/lib/anonymous-cache.unit.test.ts` — the routing decision itself: anonymous `GET`/`HEAD` collection requests, unrelated cookies, session cookies alone and mixed, `POST`, query params, `.data` URLs, `/cart`, product, `/api/*`, and cookie stripping.
- `app/lib/session-cookie.unit.test.ts` — `session` matched in any position, and not matched for `not_session`, `sessionid`, `mysession`.
- `app/lib/cache.unit.test.ts` — the 5-minute/1-hour policy, and that it carries none of `s-maxage`, `must-revalidate`, `proxy-revalidate`.
- `packages/playwright/e2e/anonymous-collection-cache.spec.ts` — the `Cf-Cache-Status` behaviour above, end to end. Skips with an explicit reason when run against a target with no cache in front of the Worker (i.e. locally).
- `packages/playwright/e2e/search-checkout-flow.spec.ts` — now also asserts browsing anonymously leaves no `session` cookie, and that adding to the cart creates one. The add → cart-contents round trip is unchanged.

Checks run: `check:format`, `check:lint`, `check:types`, `test:unit` (128 passing), `build`, `wrangler deploy --dry-run`.

## Notes for the reviewer

- The e2e cache spec **skips in CI**, by design. Since #351, Playwright runs against a locally started dev server rather than a deployed preview, and Workers Caching is not emulated there — the spec detects the absent `Cf-Cache-Status` and skips with an explicit reason rather than asserting something meaningless. The cache behaviour in the table above was verified by hand against the preview. To run the spec for real: `BASE_URL=<preview-url> pnpm --filter @glfonline/playwright test:e2e`.
- Visiting `/cart` still creates a session for an anonymous visitor, so that visitor's later collection requests bypass the cache. Left alone here to keep cart behaviour untouched; worth revisiting separately.
- A nonexistent collection handle returns 500 rather than 404. Pre-existing on `main`, not introduced here.
