### PR TITLE
Run Playwright after Cloudflare migration

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,19 +1,23 @@
 name: 🎭 Playwright
 
 on:
-  deployment_status:
-    types: [created, completed]
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   playwright:
     name: 🎭 Playwright
-    if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      BASE_URL: ${{ github.event.deployment_status.target_url }}
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v7


### PR DESCRIPTION
## What changed

Playwright now runs on pull requests and pushes to `main`, rather than waiting for a GitHub `deployment_status` event.

## Why

Cloudflare Workers Builds does not create GitHub deployment-status events. The previous workflow therefore stopped running after the Cloudflare migration. The workflow now leaves `BASE_URL` unset, so Playwright starts its configured local web server.

## Validation

- Parsed `.github/workflows/playwright.yml` as YAML
- Ran `git diff --check`
- Started `pnpm test:e2e -- --grep "SEO Meta Tags"`; Playwright reached its browser workers but did not complete locally because external app data never settled. CI already uses this same local-server path for its PR E2E smoke test.