### PR TITLE
Pin Node 24 and add test:ci script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,17 +49,8 @@ jobs:
       - name: 📥 Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
 
-      - name: 🧪 Run Unit Tests
-        run: pnpm test:unit
-
-      - name: 🌐 Run Browser Tests
-        run: pnpm test:browser
-
-      - name: 🧪 Copy test env vars
-        run: cp apps/web/.env.example apps/web/.env
-
-      - name: 🎭 Run Basic E2E Tests (PR validation)
-        run: pnpm test:e2e -- --grep "SEO Meta Tags"
+      - name: 🧪 Run CI tests
+        run: pnpm test:ci
         timeout-minutes: 15
 
       - name: 📊 Upload test results

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"sort:packages": "pnpm dlx sort-package-json 'package.json' './apps/*/package.json' './packages/*/package.json'",
 		"test": "turbo run test:browser test:e2e test:unit",
 		"test:browser": "turbo run test:browser",
+		"test:ci": "pnpm test:unit && pnpm test:browser && cp apps/web/.env.example apps/web/.env && pnpm test:e2e -- --grep \"SEO Meta Tags\"",
 		"test:e2e": "turbo run test:e2e",
 		"test:unit": "turbo run test:unit"
 	},
@@ -45,7 +46,7 @@
 		"typescript": "catalog:"
 	},
 	"engines": {
-		"node": ">=22",
+		"node": "24.x",
 		"pnpm": ">=9"
 	},
 	"packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small durable improvements for Cloud Agent and CI compatibility:

- **`engines.node: "24.x"`** — CI already reads this via `setup-node` (`node-version-file: package.json`). Node 24 provides native TypeScript config loading for `tsdown`, which the default Cloud Agent image's Node 22 lacks.
- **`test:ci`** — mirrors the `test.yml` workflow steps (unit → browser → copy `.env` → SEO e2e grep) so local and CI commands can't drift.

No `.cursor/` files, install scripts, or Cursor-specific documentation. The Cloud Agent environment is configured via the dashboard.

## Test plan

- [x] `pnpm run check` passes on Node 24
- [x] `pnpm test:ci` passes (128 unit + 59 browser + 30 e2e)
- [x] `pnpm dev:web` serves http://localhost:3000

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffe5a-7cc8-748c-a44e-04d4be326a91?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffe5a-7cc8-748c-a44e-04d4be326a91&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

